### PR TITLE
Clean up API Key mentions from examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -105,7 +105,6 @@ provider "openai" {
 
 ```hcl
 resource "openai_chat_completion" "example" {
-  api_key = var.specific_project_key  # Override provider default
   model   = "gpt-4"
   # ...
 }

--- a/examples/files/README.md
+++ b/examples/files/README.md
@@ -107,7 +107,6 @@ module "custom_api_key_file" {
 
   file_path = "path/to/file.txt"
   purpose   = "assistants"
-  api_key   = var.custom_api_key
 }
 ```
 

--- a/examples/fine_tuning/README-CHECKPOINT-PERMISSIONS.md
+++ b/examples/fine_tuning/README-CHECKPOINT-PERMISSIONS.md
@@ -110,7 +110,6 @@ resource "openai_fine_tuning_checkpoint_permission" "example" {
   
   checkpoint_id = var.checkpoint_id
   project_ids   = [var.project_id]
-  admin_api_key = var.admin_api_key
 }
 ```
 
@@ -128,7 +127,6 @@ resource "openai_fine_tuning_checkpoint_permission" "multi_project" {
     var.project_id_2,
     var.project_id_3
   ]
-  admin_api_key = var.admin_api_key
 }
 ```
 
@@ -160,7 +158,6 @@ Example output:
 ```
 # openai_fine_tuning_checkpoint_permission.checkpoint_permission[0]:
 resource "openai_fine_tuning_checkpoint_permission" "checkpoint_permission" {
-    admin_api_key = (sensitive value)
     checkpoint_id = "ft:gpt-4o-2024-08-06:org-name::AbCdEfGh"
     created_at    = 1743699340
     id            = "cp_AbCdEfGhIjKlMnOp123456"
@@ -207,7 +204,6 @@ resource "openai_fine_tuning_checkpoint_permission" "checkpoint_permission" {
   
   checkpoint_id = var.checkpoint_id
   project_ids   = [var.project_id]
-  admin_api_key = var.admin_api_key
   
   # Prevent modifications to imported resources
   lifecycle {

--- a/examples/fine_tuning/data_source_examples.tf
+++ b/examples/fine_tuning/data_source_examples.tf
@@ -173,7 +173,6 @@ data "openai_fine_tuning_checkpoint_permissions" "latest_permissions" {
   count = data.openai_fine_tuning_job.latest.status == "succeeded" ? 1 : 0
   # Use the fine_tuned_model output from the job as the checkpoint_id
   checkpoint_id = data.openai_fine_tuning_job.latest.fine_tuned_model
-  admin_api_key = var.admin_api_key  # Use admin API key from variables
 }
 
 # Comprehensive output

--- a/examples/invite/README.md
+++ b/examples/invite/README.md
@@ -149,7 +149,6 @@ An invite using a custom API key:
 resource "openai_invite" "custom_key_invite" {
   email   = "user2@example.com"
   role    = "reader"
-  api_key = var.admin_api_key  # Custom API key
 }
 ```
 

--- a/examples/organization_users/README.md
+++ b/examples/organization_users/README.md
@@ -54,7 +54,6 @@ As of version 0.X.X, the provider now supports looking up users by email address
 # Look up a user by email address
 data "openai_organization_user" "by_email" {
   email   = "user@example.com"  # Replace with a real email from your organization
-  api_key = var.openai_admin_api_key
 }
 
 # The data source will return the user's ID, which can then be used in other resources

--- a/examples/project_user/README.md
+++ b/examples/project_user/README.md
@@ -71,7 +71,6 @@ openai_admin_key = "sk-xxxx"  # Your OpenAI Admin API key
 # In main.tf - Replace with actual user IDs from your organization
 data "openai_organization_user" "user" {
   user_id = "user-yatSd6LuWvgeoqZbd89xzPlJ"  # Replace with real user ID
-  api_key = var.openai_admin_key
 }
 
 # In data_sources.tf - Replace with actual user IDs from your organization
@@ -125,7 +124,6 @@ This data source retrieves information about a specific user in your organizatio
 ```hcl
 data "openai_organization_user" "user" {
   user_id = "user-yatSd6LuWvgeoqZbd89xzPlJ"  # Must be a valid user ID
-  api_key = var.openai_admin_key  # Admin API key with api.management.read scope
 }
 
 output "user_details" {
@@ -150,7 +148,6 @@ This data source retrieves information about a specific user in your organizatio
 ```hcl
 data "openai_organization_user" "user_info" {
   user_id = "user-yatSd6LuWvgeoqZbd89xzPlJ"  # Must be a valid user ID
-  api_key = var.openai_admin_key  # Admin API key with api.management.read scope
 }
 
 output "data_source_user_email" {
@@ -166,7 +163,6 @@ output "data_source_user_role" {
 ```hcl
 data "openai_organization_user" "by_email" {
   email = "user@example.com"  # Must be a valid email address in your organization
-  api_key = var.openai_admin_key  # Admin API key with api.management.read scope
 }
 
 output "user_id_from_email" {
@@ -182,7 +178,6 @@ This data source retrieves information about all users in your organization.
 ```hcl
 data "openai_organization_users" "all_org_users" {
   limit = 50  # Number of users to return (1-100)
-  api_key = var.openai_admin_key  # Admin API key with api.management.read scope
 }
 
 output "organization_owner_count" {
@@ -267,7 +262,6 @@ This example demonstrates how to look up users by email instead of user IDs. Thi
 ```hcl
 data "openai_organization_user" "by_email" {
   email   = "user@example.com"  # Replace with a real email from your organization
-  api_key = var.openai_admin_key
 }
 
 output "org_user_by_email_id" {

--- a/examples/rate_limit/README.md
+++ b/examples/rate_limit/README.md
@@ -103,9 +103,6 @@ resource "openai_rate_limit" "dalle3_limits" {
   max_requests_per_minute = 50
   max_images_per_minute   = 10
   max_requests_per_1_day  = 600
-  
-  # Pass the API key to use for authentication
-  api_key = var.openai_api_key
 }
 ```
 
@@ -118,7 +115,6 @@ The `data_sources.tf` file demonstrates how to use both the singular and plural 
 data "openai_rate_limits" "all_limits" {
   count      = var.try_data_sources ? 1 : 0
   project_id = var.project_id
-  api_key    = var.openai_api_key
 }
 
 # Retrieve rate limit for a specific model
@@ -126,7 +122,6 @@ data "openai_rate_limit" "dalle3_limit" {
   count      = var.try_data_sources ? 1 : 0
   project_id = var.project_id
   model      = "dall-e-3"
-  api_key    = var.openai_api_key
 }
 ```
 


### PR DESCRIPTION
We used to allow overriding API key per resource. This is already removed in the code, but I found some leftovers in the examples.