### PR TITLE
Enable timeout configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,3 +45,4 @@ provider "openai" {
 - `api_key` (String, Sensitive) Project API key (sk-proj...) for authentication. Note: Use project keys, not admin keys.
 - `api_url` (String) The URL for OpenAI API. If not set, the OPENAI_API_URL environment variable will be used, or the default value of 'https://api.openai.com/v1'.
 - `organization` (String) The Organization ID for OpenAI API operations. If not set, the OPENAI_ORGANIZATION environment variable will be used.
+- `timeout` (Number) Timeout in seconds for API operations. If not set, the OPENAI_TIMEOUT environment variable will be used, or the default value of 300 seconds (5 minutes).


### PR DESCRIPTION
Some endpoints like model responses can take random time to complete. While allowing to extend the timeout doesn't fix all of the issues, it does give a chance to avoid them from happening when using this resources.

I still had some timeouts though - when I run the tests with same prompt 10 times in parallel, 2 out of 10 timed out after 15 minutes, 1 took 8 minutes, and the rest finished in less than 3 minutes. Not sure if we can handle it better on the provider side. Doesn't happen with image generation or smaller prompts.