### PR TITLE
feat: add geography (data residency) support to openai_project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `geography` attribute on `openai_project` resource to pin projects to a specific region (e.g. `us`, `eu`). Changing geography forces resource replacement.
+- `geography` attribute exposed on `openai_project` and `openai_projects` data sources.
+- Input validation restricting geography to supported values (`US`, `EU`, `JP`, `IN`, `KR`, `CA`, `AU`, `SG`).
+
 ## [1.1.0] - 2025-06-27
 ### Added
 - Timeout configuration support for provider operations (#21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `geography` attribute on `openai_project` resource to pin projects to a specific region (e.g. `us`, `eu`). Changing geography forces resource replacement.
+- `geography` attribute on `openai_project` resource to pin projects to a specific region (e.g. `US`, `EU`). Changing geography forces resource replacement.
 - `geography` attribute exposed on `openai_project` and `openai_projects` data sources.
 - Input validation restricting geography to supported values (`US`, `EU`, `JP`, `IN`, `KR`, `CA`, `AU`, `SG`).
 

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -46,6 +46,7 @@ locals {
 ### Read-Only
 
 - `created_at` (Number) The Unix timestamp (in seconds) for when the project was created.
+- `geography` (String) The data residency region of the project (e.g. `US`, `EU`, `JP`, `IN`, `KR`, `CA`, `AU`, `SG`).
 - `id` (String) The ID of the project.
 - `name` (String) The name of the project.
 - `status` (String) The status of the project.

--- a/docs/data-sources/projects.md
+++ b/docs/data-sources/projects.md
@@ -43,6 +43,7 @@ output "project_count" {
 Read-Only:
 
 - `created_at` (Number) The Unix timestamp (in seconds) for when the project was created.
+- `geography` (String) The data residency region of the project (e.g. `US`, `EU`, `JP`, `IN`, `KR`, `CA`, `AU`, `SG`).
 - `id` (String) The ID of the project.
 - `name` (String) The name of the project.
 - `status` (String) The status of the project.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -18,12 +18,18 @@ resource "openai_project" "development" {
   name = "Development Project"
 }
 
-# Create a production project
-resource "openai_project" "production" {
-  name = "Production API Services"
+# Create a production project pinned to the US region
+resource "openai_project" "production_us" {
+  name      = "Production API Services (US)"
+  geography = "US"
 }
 
-# Output the project ID
+# Create a production project pinned to the EU region
+resource "openai_project" "production_eu" {
+  name      = "Production API Services (EU)"
+  geography = "EU"
+}
+
 output "dev_project_id" {
   value       = openai_project.development.id
   description = "The ID of the development project"
@@ -36,6 +42,10 @@ output "dev_project_id" {
 ### Required
 
 - `name` (String) The name of the project.
+
+### Optional
+
+- `geography` (String) Data residency region for the project. Your organization must have access to Data residency functionality. Valid values: `US`, `EU`, `JP`, `IN`, `KR`, `CA`, `AU`, `SG`. Set at creation time and cannot be changed. Changing this value forces resource replacement.
 
 ### Read-Only
 

--- a/examples/resources/openai_project/resource.tf
+++ b/examples/resources/openai_project/resource.tf
@@ -3,13 +3,29 @@ resource "openai_project" "development" {
   name = "Development Project"
 }
 
-# Create a production project
-resource "openai_project" "production" {
-  name = "Production API Services"
+# Create a production project pinned to the US region
+resource "openai_project" "production_us" {
+  name      = "Production API Services (US)"
+  geography = "US"
 }
 
-# Output the project ID
+# Create a production project pinned to the EU region
+resource "openai_project" "production_eu" {
+  name      = "Production API Services (EU)"
+  geography = "EU"
+}
+
 output "dev_project_id" {
   value       = openai_project.development.id
   description = "The ID of the development project"
+}
+
+output "us_project_id" {
+  value       = openai_project.production_us.id
+  description = "The ID of the US production project"
+}
+
+output "eu_project_id" {
+  value       = openai_project.production_eu.id
+  description = "The ID of the EU production project"
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1063,7 +1063,7 @@ func (c *OpenAIClient) ListProjects(limit int, includeArchived bool, after strin
 }
 
 // CreateProject creates a new project with the given name and optional geography.
-// Geography restricts the project to a specific region (e.g. "us", "eu").
+// Geography restricts the project to a specific region (e.g. "US", "EU").
 func (c *OpenAIClient) CreateProject(name string, geography string) (*Project, error) {
 	requestBody := map[string]interface{}{
 		"name": name,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -141,12 +141,13 @@ func (c *OpenAIClient) SetTimeout(timeout time.Duration) {
 
 // Project represents a project in OpenAI
 type Project struct {
-	Object     string `json:"object"`
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	CreatedAt  *int64 `json:"created_at"`
-	ArchivedAt *int64 `json:"archived_at"`
-	Status     string `json:"status"`
+	Object     string  `json:"object"`
+	ID         string  `json:"id"`
+	Name       string  `json:"name"`
+	Geography  *string `json:"geography,omitempty"`
+	CreatedAt  *int64  `json:"created_at"`
+	ArchivedAt *int64  `json:"archived_at"`
+	Status     string  `json:"status"`
 }
 
 // ProjectUser represents a user associated with a project
@@ -1061,14 +1062,16 @@ func (c *OpenAIClient) ListProjects(limit int, includeArchived bool, after strin
 	return &resp, nil
 }
 
-// CreateProject creates a new project with the given name
-func (c *OpenAIClient) CreateProject(name string) (*Project, error) {
-	// Create the request body
+// CreateProject creates a new project with the given name and optional geography.
+// Geography restricts the project to a specific region (e.g. "us", "eu").
+func (c *OpenAIClient) CreateProject(name string, geography string) (*Project, error) {
 	requestBody := map[string]interface{}{
 		"name": name,
 	}
+	if geography != "" {
+		requestBody["geography"] = geography
+	}
 
-	// Debug information
 	fmt.Printf("Creating project with name: %s\n", name)
 	fmt.Printf("Request body: %+v\n", requestBody)
 

--- a/internal/provider/data_source_openai_project.go
+++ b/internal/provider/data_source_openai_project.go
@@ -27,6 +27,7 @@ type ProjectDataSourceModel struct {
 	AdminKey  types.String `tfsdk:"admin_key"`
 	ID        types.String `tfsdk:"id"`
 	Name      types.String `tfsdk:"name"`
+	Geography types.String `tfsdk:"geography"`
 	Status    types.String `tfsdk:"status"`
 	CreatedAt types.Int64  `tfsdk:"created_at"`
 }
@@ -54,6 +55,10 @@ func (d *ProjectDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 			},
 			"name": schema.StringAttribute{
 				Description: "The name of the project.",
+				Computed:    true,
+			},
+			"geography": schema.StringAttribute{
+				Description: "The data residency region of the project (e.g. US, EU, JP).",
 				Computed:    true,
 			},
 			"status": schema.StringAttribute{
@@ -187,6 +192,12 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	data.Name = types.StringValue(project.Name)
 	data.Status = types.StringValue(project.Status)
 	data.CreatedAt = types.Int64Value(project.CreatedAt)
+
+	if project.Geography != nil {
+		data.Geography = types.StringValue(*project.Geography)
+	} else {
+		data.Geography = types.StringNull()
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/data_source_openai_project.go
+++ b/internal/provider/data_source_openai_project.go
@@ -14,14 +14,17 @@ import (
 
 var _ datasource.DataSource = &ProjectDataSource{}
 
+// NewProjectDataSource returns a new instance of the openai_project data source.
 func NewProjectDataSource() datasource.DataSource {
 	return &ProjectDataSource{}
 }
 
+// ProjectDataSource implements the openai_project data source.
 type ProjectDataSource struct {
 	client *OpenAIClient
 }
 
+// ProjectDataSourceModel maps the openai_project data source schema to Go types.
 type ProjectDataSourceModel struct {
 	ProjectID types.String `tfsdk:"project_id"`
 	AdminKey  types.String `tfsdk:"admin_key"`

--- a/internal/provider/data_source_openai_projects.go
+++ b/internal/provider/data_source_openai_projects.go
@@ -33,6 +33,7 @@ type ProjectsDataSourceModel struct {
 type ProjectResultModel struct {
 	ID        types.String `tfsdk:"id"`
 	Name      types.String `tfsdk:"name"`
+	Geography types.String `tfsdk:"geography"`
 	Status    types.String `tfsdk:"status"`
 	CreatedAt types.Int64  `tfsdk:"created_at"`
 }
@@ -73,6 +74,10 @@ func (d *ProjectsDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 						},
 						"name": schema.StringAttribute{
 							Description: "The name of the project.",
+							Computed:    true,
+						},
+						"geography": schema.StringAttribute{
+							Description: "The data residency region of the project (e.g. US, EU, JP).",
 							Computed:    true,
 						},
 						"status": schema.StringAttribute{
@@ -191,9 +196,14 @@ func (d *ProjectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 		}
 
 		for _, p := range listResp.Data {
+			geo := types.StringNull()
+			if p.Geography != nil {
+				geo = types.StringValue(*p.Geography)
+			}
 			projectModel := ProjectResultModel{
 				ID:        types.StringValue(p.ID),
 				Name:      types.StringValue(p.Name),
+				Geography: geo,
 				Status:    types.StringValue(p.Status),
 				CreatedAt: types.Int64Value(p.CreatedAt),
 			}

--- a/internal/provider/data_source_openai_projects.go
+++ b/internal/provider/data_source_openai_projects.go
@@ -16,20 +16,24 @@ import (
 
 var _ datasource.DataSource = &ProjectsDataSource{}
 
+// NewProjectsDataSource returns a new instance of the openai_projects data source.
 func NewProjectsDataSource() datasource.DataSource {
 	return &ProjectsDataSource{}
 }
 
+// ProjectsDataSource implements the openai_projects data source.
 type ProjectsDataSource struct {
 	client *OpenAIClient
 }
 
+// ProjectsDataSourceModel maps the openai_projects data source schema to Go types.
 type ProjectsDataSourceModel struct {
 	AdminKey types.String         `tfsdk:"admin_key"`
 	Projects []ProjectResultModel `tfsdk:"projects"`
 	ID       types.String         `tfsdk:"id"` // Dummy ID
 }
 
+// ProjectResultModel represents a single project in the openai_projects list.
 type ProjectResultModel struct {
 	ID        types.String `tfsdk:"id"`
 	Name      types.String `tfsdk:"name"`
@@ -38,6 +42,7 @@ type ProjectResultModel struct {
 	CreatedAt types.Int64  `tfsdk:"created_at"`
 }
 
+// ProjectsListResponseFramework represents the paginated list response from the projects API.
 type ProjectsListResponseFramework struct {
 	Object  string                     `json:"object"`
 	Data    []ProjectResponseFramework `json:"data"`

--- a/internal/provider/resource_openai_project.go
+++ b/internal/provider/resource_openai_project.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mkdev-me/terraform-provider-openai/internal/client"
 )
@@ -33,6 +35,7 @@ func (r *ProjectResource) Metadata(ctx context.Context, req resource.MetadataReq
 type ProjectResourceModel struct {
 	ID         types.String `tfsdk:"id"`
 	Name       types.String `tfsdk:"name"`
+	Geography  types.String `tfsdk:"geography"`
 	Status     types.String `tfsdk:"status"`
 	CreatedAt  types.String `tfsdk:"created_at"`
 	ArchivedAt types.String `tfsdk:"archived_at"`
@@ -53,6 +56,18 @@ func (r *ProjectResource) Schema(ctx context.Context, req resource.SchemaRequest
 			"name": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The name of the project.",
+			},
+			"geography": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Data residency region for the project. Your organization must have access to Data residency functionality. Valid values: `US`, `EU`, `JP`, `IN`, `KR`, `CA`, `AU`, `SG`. Set at creation time and cannot be changed.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("US", "EU", "JP", "IN", "KR", "CA", "AU", "SG"),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"status": schema.StringAttribute{
 				Computed:            true,
@@ -97,7 +112,12 @@ func (r *ProjectResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	project, err := r.client.CreateProject(data.Name.ValueString())
+	geography := ""
+	if !data.Geography.IsNull() && !data.Geography.IsUnknown() {
+		geography = data.Geography.ValueString()
+	}
+
+	project, err := r.client.CreateProject(data.Name.ValueString(), geography)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating project", err.Error())
 		return
@@ -106,6 +126,12 @@ func (r *ProjectResource) Create(ctx context.Context, req resource.CreateRequest
 	data.ID = types.StringValue(project.ID)
 	data.Name = types.StringValue(project.Name)
 	data.Status = types.StringValue(project.Status)
+
+	if project.Geography != nil {
+		data.Geography = types.StringValue(*project.Geography)
+	} else {
+		data.Geography = types.StringNull()
+	}
 
 	if project.CreatedAt != nil {
 		data.CreatedAt = types.StringValue(time.Unix(*project.CreatedAt, 0).Format(time.RFC3339))
@@ -164,6 +190,12 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	data.Name = types.StringValue(project.Name)
 	data.Status = types.StringValue(project.Status)
 
+	if project.Geography != nil {
+		data.Geography = types.StringValue(*project.Geography)
+	} else {
+		data.Geography = types.StringNull()
+	}
+
 	if project.CreatedAt != nil {
 		data.CreatedAt = types.StringValue(time.Unix(*project.CreatedAt, 0).Format(time.RFC3339))
 	}
@@ -192,6 +224,12 @@ func (r *ProjectResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	data.Name = types.StringValue(project.Name)
 	data.Status = types.StringValue(project.Status)
+
+	if project.Geography != nil {
+		data.Geography = types.StringValue(*project.Geography)
+	} else {
+		data.Geography = types.StringNull()
+	}
 
 	if project.CreatedAt != nil {
 		data.CreatedAt = types.StringValue(time.Unix(*project.CreatedAt, 0).Format(time.RFC3339))

--- a/internal/provider/resource_openai_project.go
+++ b/internal/provider/resource_openai_project.go
@@ -20,10 +20,12 @@ import (
 var _ resource.Resource = &ProjectResource{}
 var _ resource.ResourceWithImportState = &ProjectResource{}
 
+// ProjectResource implements the openai_project managed resource.
 type ProjectResource struct {
 	client *client.OpenAIClient
 }
 
+// NewProjectResource returns a new instance of the openai_project resource.
 func NewProjectResource() resource.Resource {
 	return &ProjectResource{}
 }
@@ -32,6 +34,7 @@ func (r *ProjectResource) Metadata(ctx context.Context, req resource.MetadataReq
 	resp.TypeName = req.ProviderTypeName + "_project"
 }
 
+// ProjectResourceModel maps the openai_project schema to Go types.
 type ProjectResourceModel struct {
 	ID         types.String `tfsdk:"id"`
 	Name       types.String `tfsdk:"name"`

--- a/internal/provider/resource_openai_project_test.go
+++ b/internal/provider/resource_openai_project_test.go
@@ -66,6 +66,35 @@ func TestAccResourceOpenAIProject_update(t *testing.T) {
 	})
 }
 
+func TestAccResourceOpenAIProject_geography(t *testing.T) {
+	t.Skip("Skipping until properly implemented and OpenAI API credentials are configured for tests")
+
+	var projectID string
+	projectName := "tf-acc-test-project-geo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckOpenAIProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceOpenAIProjectWithGeography(projectName, "US"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenAIProjectExists("openai_project.test", &projectID),
+					resource.TestCheckResourceAttr("openai_project.test", "name", projectName),
+					resource.TestCheckResourceAttr("openai_project.test", "geography", "US"),
+					resource.TestCheckResourceAttrSet("openai_project.test", "created_at"),
+				),
+			},
+			{
+				ResourceName:      "openai_project.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckOpenAIProjectExists(n string, projectID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -114,4 +143,13 @@ resource "openai_project" "test" {
   name = "%s"
 }
 `, name)
+}
+
+func testAccResourceOpenAIProjectWithGeography(name, geography string) string {
+	return fmt.Sprintf(`
+resource "openai_project" "test" {
+  name      = "%s"
+  geography = "%s"
+}
+`, name, geography)
 }

--- a/internal/provider/types_project_org.go
+++ b/internal/provider/types_project_org.go
@@ -2,12 +2,13 @@ package provider
 
 // ProjectResponseFramework represents the API response for an OpenAI project.
 type ProjectResponseFramework struct {
-	ID         string `json:"id"`
-	Object     string `json:"object"`
-	Name       string `json:"name"`
-	Status     string `json:"status"`
-	CreatedAt  int64  `json:"created_at"`
-	ArchivedAt *int64 `json:"archived_at,omitempty"`
+	ID         string  `json:"id"`
+	Object     string  `json:"object"`
+	Name       string  `json:"name"`
+	Geography  *string `json:"geography,omitempty"`
+	Status     string  `json:"status"`
+	CreatedAt  int64   `json:"created_at"`
+	ArchivedAt *int64  `json:"archived_at,omitempty"`
 }
 
 // ProjectUserResponseFramework represents the API response for a project user.

--- a/modules/projects/main.tf
+++ b/modules/projects/main.tf
@@ -10,8 +10,9 @@ terraform {
 
 # Create an OpenAI project
 resource "openai_project" "project" {
-  provider = openai
-  name     = var.name
+  provider  = openai
+  name      = var.name
+  geography = var.geography
 }
 
 # Outputs from the actual project resource
@@ -23,6 +24,11 @@ output "id" {
 output "name" {
   description = "The name of the OpenAI project"
   value       = openai_project.project.name
+}
+
+output "geography" {
+  description = "The geographic region of the OpenAI project"
+  value       = openai_project.project.geography
 }
 
 output "created_at" {

--- a/modules/projects/outputs.tf
+++ b/modules/projects/outputs.tf
@@ -10,6 +10,11 @@ output "project_name" {
   value       = var.list_mode ? null : (var.create_project ? one(openai_project.project[*].name) : one(data.openai_project.project[*].name))
 }
 
+output "project_geography" {
+  description = "The geographic region of the project (only in single project mode)"
+  value       = var.list_mode ? null : (var.create_project ? one(openai_project.project[*].geography) : one(data.openai_project.project[*].geography))
+}
+
 output "project_status" {
   description = "The status of the project (only in single project mode)"
   value       = var.list_mode ? null : (var.create_project ? one(openai_project.project[*].status) : one(data.openai_project.project[*].status))

--- a/modules/projects/variables.tf
+++ b/modules/projects/variables.tf
@@ -20,6 +20,12 @@ variable "name" {
   default     = null
 }
 
+variable "geography" {
+  type        = string
+  description = "Data residency region for the project (e.g. US, EU, JP, IN, KR, CA, AU, SG). Set at creation time and cannot be changed."
+  default     = null
+}
+
 # Data source variables
 variable "project_id" {
   type        = string


### PR DESCRIPTION
## Summary

- Adds the `geography` attribute to the `openai_project` resource, enabling users to pin projects to a specific [data residency region](https://developers.openai.com/docs/guides/your-data#data-residency-controls) at creation time
- Exposes `geography` as a read-only attribute on the `openai_project` and `openai_projects` data sources
- Includes input validation for all 8 API-supported regions: `US`, `EU`, `JP`, `IN`, `KR`, `CA`, `AU`, `SG`

### Motivation

The OpenAI Projects API supports a `geography` parameter on the [Create project](https://developers.openai.com/api/reference/resources/organization/subresources/projects/methods/create) endpoint, but this provider doesn't expose it. Organizations that need data residency controls currently have to use raw API calls (e.g. via `terracurl`) to create region-pinned projects.

### Changes across layers

| Layer | Files | What changed |
|-------|-------|-------------|
| **Client** | `internal/client/client.go` | `Project` struct gains `Geography *string`; `CreateProject` accepts geography param |
| **Resource** | `resource_openai_project.go` | `geography` added as Optional+Computed with `RequiresReplace` + `OneOf` validator |
| **Data sources** | `data_source_openai_project.go`, `data_source_openai_projects.go` | Expose `geography` as computed |
| **Types** | `types_project_org.go` | `ProjectResponseFramework` gains `Geography` field |
| **Module** | `modules/projects/` | New `geography` variable, resource passthrough, outputs |
| **Tests** | `resource_openai_project_test.go` | New `TestAccResourceOpenAIProject_geography` acceptance test |
| **Docs** | `docs/resources/project.md`, `docs/data-sources/project.md`, `docs/data-sources/projects.md` | Schema docs updated |
| **Examples** | `examples/resources/openai_project/resource.tf` | Shows US and EU region-pinned projects |
| **Changelog** | `CHANGELOG.md` | `[Unreleased]` entry added |

### Usage

```hcl
resource "openai_project" "eu_production" {
  name      = "EU Production"
  geography = "EU"
}
```

Geography is immutable after creation — changing the value triggers resource replacement (archive + recreate).

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `go vet ./...` — no issues
- [x] `go test ./internal/...` — all tests pass
- [ ] Acceptance test `TestAccResourceOpenAIProject_geography` (requires API credentials; follows existing skipped-test pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `geography` attribute to `openai_project` for specifying data residency (US, EU, JP, IN, KR, CA, AU, SG); changing it forces resource replacement
  * Exposed `geography` as a read-only attribute in `openai_project` and `openai_projects` data sources

* **Documentation**
  * Updated docs, examples, and module inputs/outputs to demonstrate geography usage and region-specific examples

* **Tests**
  * Added an acceptance test scaffold for project geography verification (skipped by default)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->