### PR TITLE
fix: retry role lookup with backoff on 429/5xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The `openai_project_user` state upgrader (added in v2.2.0) now retries on
+  `429 Too Many Requests` and transient `5xx` responses from the admin API
+  using exponential backoff (1s, 2s, 4s, 8s, 16s, 30s). The admin
+  `GET /v1/projects/{id}/roles` endpoint is rate-limited; without retry, a
+  state upgrade migrating many resources can burst past the limit and fail
+  the entire `terraform plan`. Honours the `Retry-After` header when present.
+
+## [2.2.0]
+
 ### Added
 - State upgrader for `openai_project_user` to migrate state stored under the
   pre-v2.1.0 schema (string `role`) into the current schema (set `role_ids`).

--- a/internal/provider/helpers_role_lookup.go
+++ b/internal/provider/helpers_role_lookup.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -85,6 +87,11 @@ func lookupProjectRoleIDByName(ctx context.Context, c *OpenAIClient, projectID, 
 
 // listProjectRoles fetches all roles defined in a project and returns them as
 // a lowercased-name → role-ID map. Pagination is followed to completion.
+//
+// Retries on 429 (Too Many Requests) and 5xx with exponential backoff. The
+// admin API enforces a low rate limit (~60 RPM) and a state upgrade migrating
+// many resources can burst past it; without retry the upgrader fails the
+// entire plan.
 func listProjectRoles(ctx context.Context, c *OpenAIClient, projectID string) (map[string]string, error) {
 	rolesURL := adminBaseURL(c) + "/v1/projects/" + projectID + "/roles"
 	httpClient := projectClientHTTP(c)
@@ -103,16 +110,9 @@ func listProjectRoles(ctx context.Context, c *OpenAIClient, projectID string) (m
 		}
 		parsedURL.RawQuery = q.Encode()
 
-		req, err := http.NewRequestWithContext(ctx, "GET", parsedURL.String(), nil)
+		resp, err := doWithRetry(ctx, httpClient, c, parsedURL.String())
 		if err != nil {
-			return nil, fmt.Errorf("error creating roles request: %w", err)
-		}
-		setAdminAuthHeaders(c, req)
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return nil, fmt.Errorf("error executing roles request: %w", err)
+			return nil, err
 		}
 
 		if resp.StatusCode != http.StatusOK {
@@ -143,4 +143,119 @@ func listProjectRoles(ctx context.Context, c *OpenAIClient, projectID string) (m
 	}
 
 	return out, nil
+}
+
+// retryStatusCodes are HTTP status codes that should trigger a retry with
+// exponential backoff (rate limiting and transient server errors).
+var retryStatusCodes = map[int]bool{
+	http.StatusTooManyRequests:     true, // 429
+	http.StatusInternalServerError: true, // 500
+	http.StatusBadGateway:          true, // 502
+	http.StatusServiceUnavailable:  true, // 503
+	http.StatusGatewayTimeout:      true, // 504
+}
+
+// retryMaxAttempts is the maximum number of attempts (including the first)
+// the retry helper makes before giving up.
+const retryMaxAttempts = 6
+
+// doWithRetry performs a GET against urlStr with exponential backoff on 429
+// (rate limiting) and transient 5xx responses.
+//
+// The OpenAI admin API enforces a low rate limit on /v1/projects/{id}/roles
+// (a state-upgrade migrating many resources can burst past it during a single
+// `terraform plan`). Without retry the upgrader fails the entire plan.
+//
+// Honours the `Retry-After` header when present (seconds), otherwise falls
+// back to a capped exponential schedule (1s, 2s, 4s, 8s, 16s, 30s).
+func doWithRetry(ctx context.Context, httpClient *http.Client, c *OpenAIClient, urlStr string) (*http.Response, error) {
+	var lastErr error
+
+	for attempt := 0; attempt < retryMaxAttempts; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error creating request: %w", err)
+		}
+		setAdminAuthHeaders(c, req)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt == retryMaxAttempts-1 || !sleepWithBackoff(ctx, attempt, "") {
+				return nil, fmt.Errorf("transport error after %d attempts: %w", attempt+1, err)
+			}
+			continue
+		}
+
+		if !retryStatusCodes[resp.StatusCode] {
+			return resp, nil
+		}
+
+		retryAfter := resp.Header.Get("Retry-After")
+		// Drain and close so the connection can be reused for the next attempt.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if attempt == retryMaxAttempts-1 {
+			// Final attempt: re-issue once more so caller has a fresh response with body.
+			req2, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
+			if err != nil {
+				return nil, fmt.Errorf("error creating final request: %w", err)
+			}
+			setAdminAuthHeaders(c, req2)
+			req2.Header.Set("Content-Type", "application/json")
+			return httpClient.Do(req2)
+		}
+
+		if !sleepWithBackoff(ctx, attempt, retryAfter) {
+			return nil, fmt.Errorf("retry aborted: %w", ctx.Err())
+		}
+	}
+
+	return nil, lastErr
+}
+
+// sleepWithBackoff waits before the next retry attempt. Returns false if the
+// context was cancelled while waiting.
+func sleepWithBackoff(ctx context.Context, attempt int, retryAfter string) bool {
+	d := backoffDuration(attempt, retryAfter)
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// backoffDuration returns the wait time for a given attempt index. If
+// retryAfter (the value of the `Retry-After` header) is a non-negative integer
+// number of seconds, that value wins (capped at 60s; 0 means "retry now").
+// Otherwise we use 1, 2, 4, 8, 16, 30s.
+func backoffDuration(attempt int, retryAfter string) time.Duration {
+	if retryAfter != "" {
+		if secs, err := strconv.Atoi(strings.TrimSpace(retryAfter)); err == nil && secs >= 0 {
+			capped := secs
+			if capped > 60 {
+				capped = 60
+			}
+			return time.Duration(capped) * time.Second
+		}
+	}
+	switch attempt {
+	case 0:
+		return 1 * time.Second
+	case 1:
+		return 2 * time.Second
+	case 2:
+		return 4 * time.Second
+	case 3:
+		return 8 * time.Second
+	case 4:
+		return 16 * time.Second
+	default:
+		return 30 * time.Second
+	}
 }

--- a/internal/provider/helpers_role_lookup.go
+++ b/internal/provider/helpers_role_lookup.go
@@ -192,21 +192,16 @@ func doWithRetry(ctx context.Context, httpClient *http.Client, c *OpenAIClient, 
 			return resp, nil
 		}
 
+		// Final attempt: hand the (still-retryable) response back to the caller
+		// untouched so the body remains readable for diagnostics.
+		if attempt == retryMaxAttempts-1 {
+			return resp, nil
+		}
+
+		// Going to retry: drain and close so the connection can be reused.
 		retryAfter := resp.Header.Get("Retry-After")
-		// Drain and close so the connection can be reused for the next attempt.
 		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
-
-		if attempt == retryMaxAttempts-1 {
-			// Final attempt: re-issue once more so caller has a fresh response with body.
-			req2, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
-			if err != nil {
-				return nil, fmt.Errorf("error creating final request: %w", err)
-			}
-			setAdminAuthHeaders(c, req2)
-			req2.Header.Set("Content-Type", "application/json")
-			return httpClient.Do(req2)
-		}
 
 		if !sleepWithBackoff(ctx, attempt, retryAfter) {
 			return nil, fmt.Errorf("retry aborted: %w", ctx.Err())

--- a/internal/provider/helpers_role_lookup_test.go
+++ b/internal/provider/helpers_role_lookup_test.go
@@ -333,11 +333,9 @@ func TestDoWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error after exhausting retries, got nil")
 	}
-	// retryMaxAttempts = 6, plus the final re-issue inside doWithRetry, then
-	// listProjectRoles surfaces the non-OK response as an error. We expect
-	// at least retryMaxAttempts attempts to have been made.
-	if calls < retryMaxAttempts {
-		t.Errorf("expected at least %d calls, got %d", retryMaxAttempts, calls)
+	// Exactly retryMaxAttempts requests should be made — no extra reissue.
+	if calls != retryMaxAttempts {
+		t.Errorf("expected exactly %d calls, got %d", retryMaxAttempts, calls)
 	}
 }
 

--- a/internal/provider/helpers_role_lookup_test.go
+++ b/internal/provider/helpers_role_lookup_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mkdev-me/terraform-provider-openai/internal/client"
 )
@@ -247,5 +248,129 @@ func TestLookupProjectRoleIDByName_CacheRemembersMisses(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("expected exactly 1 API call, got %d", calls)
+	}
+}
+
+// Override the test backoff to be near-instant so retry tests don't take ages.
+// We swap the default backoff with a fixed 5ms wait via a test-only knob.
+// (Using a tiny default in code would make production retries useless, so we
+// keep production fast-on-no-retry-after but tests use Retry-After header.)
+
+func TestDoWithRetry_RetriesOn429(t *testing.T) {
+	resetRoleCacheForTest()
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls < 3 {
+			w.Header().Set("Retry-After", "0") // honour: 0 => immediate retry
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"object":   "list",
+			"data":     []map[string]interface{}{{"id": "role_member_id", "name": "member"}},
+			"has_more": false,
+		})
+	}))
+	defer server.Close()
+
+	c := newTestOpenAIClient(server.URL)
+	got, err := lookupProjectRoleIDByName(context.Background(), c, "proj_retry", "member")
+	if err != nil {
+		t.Fatalf("expected eventual success, got error: %v", err)
+	}
+	if got != "role_member_id" {
+		t.Errorf("got role ID %q, want %q", got, "role_member_id")
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls (2 × 429 + 1 × 200), got %d", calls)
+	}
+}
+
+func TestDoWithRetry_RetriesOn5xx(t *testing.T) {
+	resetRoleCacheForTest()
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "0")
+			http.Error(w, "transient", http.StatusBadGateway)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"object":   "list",
+			"data":     []map[string]interface{}{{"id": "role_x", "name": "member"}},
+			"has_more": false,
+		})
+	}))
+	defer server.Close()
+
+	c := newTestOpenAIClient(server.URL)
+	got, err := lookupProjectRoleIDByName(context.Background(), c, "proj_5xx", "member")
+	if err != nil {
+		t.Fatalf("expected eventual success, got: %v", err)
+	}
+	if got != "role_x" {
+		t.Errorf("got %q, want %q", got, "role_x")
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls (1 × 502 + 1 × 200), got %d", calls)
+	}
+}
+
+func TestDoWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	resetRoleCacheForTest()
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Retry-After", "0")
+		http.Error(w, "still rate limited", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	c := newTestOpenAIClient(server.URL)
+	_, err := lookupProjectRoleIDByName(context.Background(), c, "proj_giveup", "member")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	// retryMaxAttempts = 6, plus the final re-issue inside doWithRetry, then
+	// listProjectRoles surfaces the non-OK response as an error. We expect
+	// at least retryMaxAttempts attempts to have been made.
+	if calls < retryMaxAttempts {
+		t.Errorf("expected at least %d calls, got %d", retryMaxAttempts, calls)
+	}
+}
+
+func TestDoWithRetry_DoesNotRetryOn4xxOtherThan429(t *testing.T) {
+	resetRoleCacheForTest()
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	c := newTestOpenAIClient(server.URL)
+	_, err := lookupProjectRoleIDByName(context.Background(), c, "proj_403", "member")
+	if err == nil {
+		t.Fatal("expected error on 403, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("403 should not retry; expected 1 call, got %d", calls)
+	}
+}
+
+func TestBackoffDuration_HonoursRetryAfter(t *testing.T) {
+	if got := backoffDuration(0, "5"); got.Seconds() != 5 {
+		t.Errorf("retry-after=5 → %v, want 5s", got)
+	}
+	if got := backoffDuration(0, "120"); got.Seconds() != 60 {
+		t.Errorf("retry-after=120 should cap at 60s, got %v", got)
+	}
+	if got := backoffDuration(0, "not-a-number"); got != 1*time.Second {
+		t.Errorf("invalid retry-after should fall back, got %v", got)
+	}
+	if got := backoffDuration(2, ""); got != 4*time.Second {
+		t.Errorf("attempt 2 with no retry-after → %v, want 4s", got)
 	}
 }


### PR DESCRIPTION
## Summary

The state upgrader for \`openai_project_user\` (added in v2.2.0) calls
\`GET /v1/projects/{id}/roles\` to resolve role names to IDs during state
migration. When a workspace migrates many resources during a single
\`terraform plan\`, the burst of role-list calls (one per unique project)
can exceed the admin API's rate limit. Without retry, **the upgrader
fails immediately on the first 429** and the entire plan errors out.

## Fix

\`listProjectRoles\` now goes through a new \`doWithRetry\` helper that
retries on:
- \`429 Too Many Requests\`
- \`5xx\` transient server errors

with exponential backoff (1s, 2s, 4s, 8s, 16s, 30s) up to 6 attempts.
Honours the \`Retry-After\` header when present (capped at 60s).

\`4xx\` other than 429 is **not** retried — those are caller errors
(unauthorized, not found, etc.) and shouldn't be papered over.

## Tests

5 new unit tests covering:
- Success after 2× 429
- Success after 1× 5xx
- Gives up after max attempts
- 4xx other than 429 not retried
- \`Retry-After\` header parsing (number, capped at 60s, invalid → fallback)

## Version

This is a bug fix — should release as v2.2.1 (label: \`bug\`).

## Compatibility

Pure addition. No schema changes. Drop-in replacement for v2.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retry handling for API requests encountering rate limits and transient server errors, including exponential backoff and support for configurable timeout headers.

* **Tests**
  * Added test coverage for retry behavior and backoff calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->