### PR TITLE
fix: retry openai_project_role data source on 429/5xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- The `openai_project_role` data source (singular and plural) now retries on
+  `429 Too Many Requests` and transient `5xx` responses from the admin API,
+  using the same exponential backoff helper that the state upgrader uses
+  (introduced in v2.2.1). Without retry, a `terraform plan` declaring many
+  `data "openai_project_role"` lookups against the same admin API can burst
+  past the rate limit and fail the entire plan with `Status: 429 Too Many
+  Requests`.
+
+## [2.2.1]
+
+### Fixed
 - The `openai_project_user` state upgrader (added in v2.2.0) now retries on
   `429 Too Many Requests` and transient `5xx` responses from the admin API
   using exponential backoff (1s, 2s, 4s, 8s, 16s, 30s). The admin

--- a/internal/provider/data_source_openai_project_role.go
+++ b/internal/provider/data_source_openai_project_role.go
@@ -157,18 +157,7 @@ func (d *ProjectRolesDataSource) Read(ctx context.Context, req datasource.ReadRe
 		}
 		parsedURL.RawQuery = q.Encode()
 
-		httpRequest, err := http.NewRequest("GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating request", err.Error())
-			return
-		}
-		httpRequest.Header.Set("Authorization", "Bearer "+adminKey)
-		httpRequest.Header.Set("Content-Type", "application/json")
-		if d.client.OpenAIClient.OrganizationID != "" {
-			httpRequest.Header.Set("OpenAI-Organization", d.client.OpenAIClient.OrganizationID)
-		}
-
-		httpResp, err := httpClient.Do(httpRequest)
+		httpResp, err := doWithRetry(ctx, httpClient, d.client, parsedURL.String())
 		if err != nil {
 			resp.Diagnostics.AddError("Error executing request", err.Error())
 			return
@@ -356,18 +345,7 @@ func (d *ProjectRoleDataSource) Read(ctx context.Context, req datasource.ReadReq
 		}
 		parsedURL.RawQuery = q.Encode()
 
-		httpRequest, err := http.NewRequest("GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating request", err.Error())
-			return
-		}
-		httpRequest.Header.Set("Authorization", "Bearer "+adminKey)
-		httpRequest.Header.Set("Content-Type", "application/json")
-		if d.client.OpenAIClient.OrganizationID != "" {
-			httpRequest.Header.Set("OpenAI-Organization", d.client.OpenAIClient.OrganizationID)
-		}
-
-		httpResp, err := httpClient.Do(httpRequest)
+		httpResp, err := doWithRetry(ctx, httpClient, d.client, parsedURL.String())
 		if err != nil {
 			resp.Diagnostics.AddError("Error executing request", err.Error())
 			return


### PR DESCRIPTION
## Summary

In v2.2.1 we added retry+backoff to the state upgrader (\`listProjectRoles\` helper). But \`data "openai_project_role"\` (both singular and plural) has its own \`httpClient.Do(req)\` that fails immediately on 429 — independent of the upgrader.

In production at Babbel a \`terraform plan\` with 12 \`data.openai_project_role\` lookups burst past the admin API rate limit, surfacing:

\`\`\`
Error: API Error
Status: 429 Too Many Requests
   with data.openai_project_role.convo_pro_ai_staging_member,
\`\`\`

## Fix

Both data source loops now use the existing \`doWithRetry\` helper (introduced in v2.2.1), which:
- Retries 429 and 5xx with exponential backoff (1, 2, 4, 8, 16, 30s).
- Honours \`Retry-After\` header.
- Caps total attempts at \`retryMaxAttempts\`.

No new helper logic — just calling the existing one from one more code path.

Net diff: removed manual \`http.NewRequest\` + header setting that \`doWithRetry\` already does, replaced with a single call.

## Tests

\`doWithRetry\` already has 5 unit tests (added in v2.2.1) covering 429 retry, 5xx retry, give-up after max, no-retry on other 4xx, and \`Retry-After\` parsing. Those still pass; this PR doesn't change retry semantics, just routes another call site through the same tested helper.

## Version

Bug fix → release as **v2.2.2** (label: \`bug\`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI project role data sources now automatically retry when encountering rate limit errors (429 responses) and transient server errors, preventing `terraform plan` failures during bulk role lookups targeting the same admin API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->