### PR TITLE
fix: retry all admin-API calls + add jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- All admin-API HTTP calls in the `openai_project_group` resource (Create/
+  Read/Update/Delete), the `openai_project_user` resource (Create/Read/
+  Update/Delete), and the `openai_group` data source now retry on `429 Too
+  Many Requests` and transient `5xx` responses, using the same backoff
+  helper introduced in v2.2.1. Previously only the `openai_project_role`
+  data source (v2.2.2) and the v0→v1 state upgrader (v2.2.1) were covered,
+  leaving plans that read groups and applies that create/update/delete
+  project memberships exposed: a `terraform apply` attaching ~14 groups to
+  a single project consistently failed with `API error listing project
+  groups: 429`.
+- Backoff schedule now applies full jitter (actual sleep is uniformly
+  random in `[base/2, base]` for base values 1, 2, 4, 8, 16, 30s). Without
+  jitter, N concurrent requests that all 429 at the same moment retry on
+  the same instants and keep colliding; jitter spreads them out and lets
+  the rate-limit window drain.
+
+## [2.2.2]
+
+### Fixed
 - The `openai_project_role` data source (singular and plural) now retries on
   `429 Too Many Requests` and transient `5xx` responses from the admin API,
   using the same exponential backoff helper that the state upgrader uses

--- a/internal/provider/data_source_openai_group.go
+++ b/internal/provider/data_source_openai_group.go
@@ -133,19 +133,7 @@ func (d *GroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		}
 		parsedURL.RawQuery = q.Encode()
 
-		httpRequest, err := http.NewRequest("GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating request", err.Error())
-			return
-		}
-
-		httpRequest.Header.Set("Authorization", "Bearer "+adminKey)
-		httpRequest.Header.Set("Content-Type", "application/json")
-		if d.client.OpenAIClient.OrganizationID != "" {
-			httpRequest.Header.Set("OpenAI-Organization", d.client.OpenAIClient.OrganizationID)
-		}
-
-		httpResp, err := httpClient.Do(httpRequest)
+		httpResp, err := doRequestWithRetry(ctx, httpClient, d.client, "GET", parsedURL.String(), nil)
 		if err != nil {
 			resp.Diagnostics.AddError("Error executing request", err.Error())
 			return
@@ -344,18 +332,7 @@ func (d *GroupsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		}
 		parsedURL.RawQuery = q.Encode()
 
-		httpRequest, err := http.NewRequest("GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating request", err.Error())
-			return
-		}
-		httpRequest.Header.Set("Authorization", "Bearer "+adminKey)
-		httpRequest.Header.Set("Content-Type", "application/json")
-		if d.client.OpenAIClient.OrganizationID != "" {
-			httpRequest.Header.Set("OpenAI-Organization", d.client.OpenAIClient.OrganizationID)
-		}
-
-		httpResp, err := httpClient.Do(httpRequest)
+		httpResp, err := doRequestWithRetry(ctx, httpClient, d.client, "GET", parsedURL.String(), nil)
 		if err != nil {
 			resp.Diagnostics.AddError("Error executing request", err.Error())
 			return

--- a/internal/provider/helpers_role_lookup.go
+++ b/internal/provider/helpers_role_lookup.go
@@ -1,10 +1,12 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -162,17 +164,37 @@ const retryMaxAttempts = 6
 // doWithRetry performs a GET against urlStr with exponential backoff on 429
 // (rate limiting) and transient 5xx responses.
 //
-// The OpenAI admin API enforces a low rate limit on /v1/projects/{id}/roles
-// (a state-upgrade migrating many resources can burst past it during a single
-// `terraform plan`). Without retry the upgrader fails the entire plan.
+// Thin wrapper for backward compatibility. New code should use
+// doRequestWithRetry directly.
+func doWithRetry(ctx context.Context, httpClient *http.Client, c *OpenAIClient, urlStr string) (*http.Response, error) {
+	return doRequestWithRetry(ctx, httpClient, c, "GET", urlStr, nil)
+}
+
+// doRequestWithRetry performs an HTTP request (any method, optional body) with
+// exponential backoff and jitter on 429 (rate limiting) and transient 5xx
+// responses.
+//
+// The OpenAI admin API enforces a low rate limit (~60 RPM org-wide); a
+// terraform plan or apply touching many project users/groups can burst past
+// it. Without retry the operation fails the entire run.
+//
+// `body` is the optional JSON request body — pass nil for GET/DELETE. The
+// body bytes are buffered and a fresh reader is created per attempt, so
+// retries replay the request faithfully.
 //
 // Honours the `Retry-After` header when present (seconds), otherwise falls
-// back to a capped exponential schedule (1s, 2s, 4s, 8s, 16s, 30s).
-func doWithRetry(ctx context.Context, httpClient *http.Client, c *OpenAIClient, urlStr string) (*http.Response, error) {
+// back to a capped exponential schedule with full jitter (base values
+// 1s, 2s, 4s, 8s, 16s, 30s — actual sleep is uniformly random in [base/2,
+// base] to avoid thundering-herd when many concurrent retries fire).
+func doRequestWithRetry(ctx context.Context, httpClient *http.Client, c *OpenAIClient, method, urlStr string, body []byte) (*http.Response, error) {
 	var lastErr error
 
 	for attempt := 0; attempt < retryMaxAttempts; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
+		var bodyReader io.Reader
+		if body != nil {
+			bodyReader = bytes.NewReader(body)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, urlStr, bodyReader)
 		if err != nil {
 			return nil, fmt.Errorf("error creating request: %w", err)
 		}
@@ -228,7 +250,10 @@ func sleepWithBackoff(ctx context.Context, attempt int, retryAfter string) bool 
 // backoffDuration returns the wait time for a given attempt index. If
 // retryAfter (the value of the `Retry-After` header) is a non-negative integer
 // number of seconds, that value wins (capped at 60s; 0 means "retry now").
-// Otherwise we use 1, 2, 4, 8, 16, 30s.
+// Otherwise we use a capped exponential schedule with "decorrelated" jitter:
+// the actual sleep is uniformly random in [base/2, base] for base values 1,
+// 2, 4, 8, 16, 30s. The jitter avoids thundering-herd when N concurrent
+// requests all 429 at once and would otherwise retry on the same schedule.
 func backoffDuration(attempt int, retryAfter string) time.Duration {
 	if retryAfter != "" {
 		if secs, err := strconv.Atoi(strings.TrimSpace(retryAfter)); err == nil && secs >= 0 {
@@ -239,18 +264,21 @@ func backoffDuration(attempt int, retryAfter string) time.Duration {
 			return time.Duration(capped) * time.Second
 		}
 	}
+	var base time.Duration
 	switch attempt {
 	case 0:
-		return 1 * time.Second
+		base = 1 * time.Second
 	case 1:
-		return 2 * time.Second
+		base = 2 * time.Second
 	case 2:
-		return 4 * time.Second
+		base = 4 * time.Second
 	case 3:
-		return 8 * time.Second
+		base = 8 * time.Second
 	case 4:
-		return 16 * time.Second
+		base = 16 * time.Second
 	default:
-		return 30 * time.Second
+		base = 30 * time.Second
 	}
+	half := base / 2
+	return half + time.Duration(rand.Int63n(int64(half)+1))
 }

--- a/internal/provider/helpers_role_lookup_test.go
+++ b/internal/provider/helpers_role_lookup_test.go
@@ -359,16 +359,30 @@ func TestDoWithRetry_DoesNotRetryOn4xxOtherThan429(t *testing.T) {
 }
 
 func TestBackoffDuration_HonoursRetryAfter(t *testing.T) {
+	// Retry-After header values are honoured exactly (no jitter applied).
 	if got := backoffDuration(0, "5"); got.Seconds() != 5 {
 		t.Errorf("retry-after=5 → %v, want 5s", got)
 	}
 	if got := backoffDuration(0, "120"); got.Seconds() != 60 {
 		t.Errorf("retry-after=120 should cap at 60s, got %v", got)
 	}
-	if got := backoffDuration(0, "not-a-number"); got != 1*time.Second {
-		t.Errorf("invalid retry-after should fall back, got %v", got)
+	// Fallback path uses jittered exponential backoff: actual sleep is in
+	// [base/2, base] for base values 1, 2, 4, 8, 16, 30s.
+	for _, tc := range []struct {
+		attempt int
+		base    time.Duration
+	}{
+		{0, 1 * time.Second},
+		{2, 4 * time.Second},
+		{5, 30 * time.Second},
+	} {
+		got := backoffDuration(tc.attempt, "")
+		if got < tc.base/2 || got > tc.base {
+			t.Errorf("attempt %d → %v, want in [%v, %v]", tc.attempt, got, tc.base/2, tc.base)
+		}
 	}
-	if got := backoffDuration(2, ""); got != 4*time.Second {
-		t.Errorf("attempt 2 with no retry-after → %v, want 4s", got)
+	got := backoffDuration(0, "not-a-number")
+	if got < 500*time.Millisecond || got > 1*time.Second {
+		t.Errorf("invalid retry-after should fall back to attempt 0 jitter range [500ms, 1s], got %v", got)
 	}
 }

--- a/internal/provider/resource_openai_project_group.go
+++ b/internal/provider/resource_openai_project_group.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -155,15 +154,7 @@ func (r *ProjectGroupResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	addURL := adminBaseURL(r.client) + "/v1/organization/projects/" + projectID + "/groups"
-	httpReq, err := http.NewRequest("POST", addURL, bytes.NewReader(body))
-	if err != nil {
-		resp.Diagnostics.AddError("Error creating request", err.Error())
-		return
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	setAdminAuthHeaders(r.client, httpReq)
-
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := doRequestWithRetry(ctx, httpClient, r.client, "POST", addURL, body)
 	if err != nil {
 		resp.Diagnostics.AddError("Error adding group to project", err.Error())
 		return
@@ -196,14 +187,7 @@ func (r *ProjectGroupResource) Create(ctx context.Context, req resource.CreateRe
 		}
 		parsedURL.RawQuery = q.Encode()
 
-		listReq, err := http.NewRequest("GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating request", err.Error())
-			return
-		}
-		setAdminAuthHeaders(r.client, listReq)
-
-		listResp, err := httpClient.Do(listReq)
+		listResp, err := doRequestWithRetry(ctx, httpClient, r.client, "GET", parsedURL.String(), nil)
 		if err != nil {
 			resp.Diagnostics.AddError("Error listing project groups", err.Error())
 			return
@@ -250,15 +234,7 @@ func (r *ProjectGroupResource) Create(ctx context.Context, req resource.CreateRe
 		}
 
 		assignURL := adminBaseURL(r.client) + "/v1/projects/" + projectID + "/groups/" + groupID + "/roles"
-		assignReq, err := http.NewRequest("POST", assignURL, bytes.NewReader(assignBody))
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating role assign request", err.Error())
-			return
-		}
-		assignReq.Header.Set("Content-Type", "application/json")
-		setAdminAuthHeaders(r.client, assignReq)
-
-		assignResp, err := httpClient.Do(assignReq)
+		assignResp, err := doRequestWithRetry(ctx, httpClient, r.client, "POST", assignURL, assignBody)
 		if err != nil {
 			resp.Diagnostics.AddError("Error assigning role to group", err.Error())
 			return
@@ -314,14 +290,7 @@ func (r *ProjectGroupResource) Read(ctx context.Context, req resource.ReadReques
 		}
 		parsedURL.RawQuery = q.Encode()
 
-		apiReq, err := http.NewRequest("GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating request", err.Error())
-			return
-		}
-		setAdminAuthHeaders(r.client, apiReq)
-
-		apiResp, err := httpClient.Do(apiReq)
+		apiResp, err := doRequestWithRetry(ctx, httpClient, r.client, "GET", parsedURL.String(), nil)
 		if err != nil {
 			resp.Diagnostics.AddError("Error listing project groups", err.Error())
 			return
@@ -390,14 +359,7 @@ func (r *ProjectGroupResource) Read(ctx context.Context, req resource.ReadReques
 		}
 		parsedURL.RawQuery = q.Encode()
 
-		rolesReq, err := http.NewRequest("GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating roles request", err.Error())
-			return
-		}
-		setAdminAuthHeaders(r.client, rolesReq)
-
-		rolesResp, err := httpClient.Do(rolesReq)
+		rolesResp, err := doRequestWithRetry(ctx, httpClient, r.client, "GET", parsedURL.String(), nil)
 		if err != nil {
 			resp.Diagnostics.AddError("Error reading group roles", err.Error())
 			return
@@ -484,14 +446,7 @@ func (r *ProjectGroupResource) Update(ctx context.Context, req resource.UpdateRe
 		if !newSet[id] {
 			unassignURL := adminBaseURL(r.client) + "/v1/projects/" + projectID + "/groups/" + groupID + "/roles/" + id
 			tflog.Info(ctx, "Unassigning role", map[string]interface{}{"url": unassignURL, "role_id": id})
-			unassignReq, err := http.NewRequest("DELETE", unassignURL, nil)
-			if err != nil {
-				resp.Diagnostics.AddError("Error creating role unassign request", err.Error())
-				return
-			}
-			setAdminAuthHeaders(r.client, unassignReq)
-
-			unassignResp, err := httpClient.Do(unassignReq)
+			unassignResp, err := doRequestWithRetry(ctx, httpClient, r.client, "DELETE", unassignURL, nil)
 			if err != nil {
 				resp.Diagnostics.AddError("Error unassigning role", err.Error())
 				return
@@ -517,15 +472,7 @@ func (r *ProjectGroupResource) Update(ctx context.Context, req resource.UpdateRe
 
 			assignURL := adminBaseURL(r.client) + "/v1/projects/" + projectID + "/groups/" + groupID + "/roles"
 			tflog.Info(ctx, "Assigning role", map[string]interface{}{"url": assignURL, "role_id": id})
-			assignReq, err := http.NewRequest("POST", assignURL, bytes.NewReader(assignBody))
-			if err != nil {
-				resp.Diagnostics.AddError("Error creating role assign request", err.Error())
-				return
-			}
-			assignReq.Header.Set("Content-Type", "application/json")
-			setAdminAuthHeaders(r.client, assignReq)
-
-			assignResp, err := httpClient.Do(assignReq)
+			assignResp, err := doRequestWithRetry(ctx, httpClient, r.client, "POST", assignURL, assignBody)
 			if err != nil {
 				resp.Diagnostics.AddError("Error assigning role", err.Error())
 				return
@@ -567,14 +514,7 @@ func (r *ProjectGroupResource) Delete(ctx context.Context, req resource.DeleteRe
 	// Step 1: Unassign all roles
 	for _, roleID := range roleIDsFromSet(data.RoleIDs) {
 		unassignURL := adminBaseURL(r.client) + "/v1/projects/" + projectID + "/groups/" + groupID + "/roles/" + roleID
-		unassignReq, err := http.NewRequest("DELETE", unassignURL, nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating role unassign request", err.Error())
-			return
-		}
-		setAdminAuthHeaders(r.client, unassignReq)
-
-		unassignResp, err := httpClient.Do(unassignReq)
+		unassignResp, err := doRequestWithRetry(ctx, httpClient, r.client, "DELETE", unassignURL, nil)
 		if err != nil {
 			resp.Diagnostics.AddError("Error unassigning role from group", err.Error())
 			return
@@ -589,14 +529,7 @@ func (r *ProjectGroupResource) Delete(ctx context.Context, req resource.DeleteRe
 
 	// Step 2: Remove group from project
 	removeURL := adminBaseURL(r.client) + "/v1/organization/projects/" + projectID + "/groups/" + groupID
-	removeReq, err := http.NewRequest("DELETE", removeURL, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error creating request", err.Error())
-		return
-	}
-	setAdminAuthHeaders(r.client, removeReq)
-
-	removeResp, err := httpClient.Do(removeReq)
+	removeResp, err := doRequestWithRetry(ctx, httpClient, r.client, "DELETE", removeURL, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error removing group from project", err.Error())
 		return

--- a/internal/provider/resource_openai_project_user.go
+++ b/internal/provider/resource_openai_project_user.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -136,15 +135,7 @@ func (r *ProjectUserResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	addURL := adminBaseURL(r.client) + "/v1/organization/projects/" + projectID + "/users"
-	httpReq, err := http.NewRequest("POST", addURL, bytes.NewReader(body))
-	if err != nil {
-		resp.Diagnostics.AddError("Error creating request", err.Error())
-		return
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	setAdminAuthHeaders(r.client, httpReq)
-
-	httpResp, err := httpClient.Do(httpReq)
+	httpResp, err := doRequestWithRetry(ctx, httpClient, r.client, "POST", addURL, body)
 	if err != nil {
 		resp.Diagnostics.AddError("Error adding user to project", err.Error())
 		return
@@ -162,14 +153,7 @@ func (r *ProjectUserResource) Create(ctx context.Context, req resource.CreateReq
 
 	// Read user details from the project (works whether we just added or already existed)
 	getUserURL := adminBaseURL(r.client) + "/v1/organization/projects/" + projectID + "/users/" + userID
-	getUserReq, err := http.NewRequest("GET", getUserURL, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error creating request", err.Error())
-		return
-	}
-	setAdminAuthHeaders(r.client, getUserReq)
-
-	getUserResp, err := httpClient.Do(getUserReq)
+	getUserResp, err := doRequestWithRetry(ctx, httpClient, r.client, "GET", getUserURL, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading project user", err.Error())
 		return
@@ -197,15 +181,7 @@ func (r *ProjectUserResource) Create(ctx context.Context, req resource.CreateReq
 		}
 
 		assignURL := adminBaseURL(r.client) + "/v1/projects/" + projectID + "/users/" + userID + "/roles"
-		assignReq, err := http.NewRequest("POST", assignURL, bytes.NewReader(assignBody))
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating role assign request", err.Error())
-			return
-		}
-		assignReq.Header.Set("Content-Type", "application/json")
-		setAdminAuthHeaders(r.client, assignReq)
-
-		assignResp, err := httpClient.Do(assignReq)
+		assignResp, err := doRequestWithRetry(ctx, httpClient, r.client, "POST", assignURL, assignBody)
 		if err != nil {
 			resp.Diagnostics.AddError("Error assigning role to user", err.Error())
 			return
@@ -244,14 +220,7 @@ func (r *ProjectUserResource) Read(ctx context.Context, req resource.ReadRequest
 
 	// Step 1: Verify the user is still in the project
 	userURL := adminBaseURL(r.client) + "/v1/organization/projects/" + projectID + "/users/" + userID
-	apiReq, err := http.NewRequest("GET", userURL, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error creating request", err.Error())
-		return
-	}
-	setAdminAuthHeaders(r.client, apiReq)
-
-	apiResp, err := httpClient.Do(apiReq)
+	apiResp, err := doRequestWithRetry(ctx, httpClient, r.client, "GET", userURL, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading project user", err.Error())
 		return
@@ -297,14 +266,7 @@ func (r *ProjectUserResource) Read(ctx context.Context, req resource.ReadRequest
 		}
 		parsedURL.RawQuery = q.Encode()
 
-		rolesReq, err := http.NewRequest("GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating roles request", err.Error())
-			return
-		}
-		setAdminAuthHeaders(r.client, rolesReq)
-
-		rolesResp, err := httpClient.Do(rolesReq)
+		rolesResp, err := doRequestWithRetry(ctx, httpClient, r.client, "GET", parsedURL.String(), nil)
 		if err != nil {
 			resp.Diagnostics.AddError("Error reading user roles", err.Error())
 			return
@@ -386,14 +348,7 @@ func (r *ProjectUserResource) Update(ctx context.Context, req resource.UpdateReq
 		if !newSet[id] {
 			unassignURL := adminBaseURL(r.client) + "/v1/projects/" + projectID + "/users/" + userID + "/roles/" + id
 			tflog.Info(ctx, "Unassigning role from user", map[string]interface{}{"role_id": id})
-			unassignReq, err := http.NewRequest("DELETE", unassignURL, nil)
-			if err != nil {
-				resp.Diagnostics.AddError("Error creating role unassign request", err.Error())
-				return
-			}
-			setAdminAuthHeaders(r.client, unassignReq)
-
-			unassignResp, err := httpClient.Do(unassignReq)
+			unassignResp, err := doRequestWithRetry(ctx, httpClient, r.client, "DELETE", unassignURL, nil)
 			if err != nil {
 				resp.Diagnostics.AddError("Error unassigning role", err.Error())
 				return
@@ -419,15 +374,7 @@ func (r *ProjectUserResource) Update(ctx context.Context, req resource.UpdateReq
 
 			assignURL := adminBaseURL(r.client) + "/v1/projects/" + projectID + "/users/" + userID + "/roles"
 			tflog.Info(ctx, "Assigning role to user", map[string]interface{}{"role_id": id})
-			assignReq, err := http.NewRequest("POST", assignURL, bytes.NewReader(assignBody))
-			if err != nil {
-				resp.Diagnostics.AddError("Error creating role assign request", err.Error())
-				return
-			}
-			assignReq.Header.Set("Content-Type", "application/json")
-			setAdminAuthHeaders(r.client, assignReq)
-
-			assignResp, err := httpClient.Do(assignReq)
+			assignResp, err := doRequestWithRetry(ctx, httpClient, r.client, "POST", assignURL, assignBody)
 			if err != nil {
 				resp.Diagnostics.AddError("Error assigning role", err.Error())
 				return
@@ -469,14 +416,7 @@ func (r *ProjectUserResource) Delete(ctx context.Context, req resource.DeleteReq
 	// Step 1: Unassign all roles
 	for _, roleID := range roleIDsFromSet(data.RoleIDs) {
 		unassignURL := adminBaseURL(r.client) + "/v1/projects/" + projectID + "/users/" + userID + "/roles/" + roleID
-		unassignReq, err := http.NewRequest("DELETE", unassignURL, nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error creating role unassign request", err.Error())
-			return
-		}
-		setAdminAuthHeaders(r.client, unassignReq)
-
-		unassignResp, err := httpClient.Do(unassignReq)
+		unassignResp, err := doRequestWithRetry(ctx, httpClient, r.client, "DELETE", unassignURL, nil)
 		if err != nil {
 			resp.Diagnostics.AddError("Error unassigning role from user", err.Error())
 			return
@@ -490,14 +430,7 @@ func (r *ProjectUserResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	// Step 2: Remove user from project
 	removeURL := adminBaseURL(r.client) + "/v1/organization/projects/" + projectID + "/users/" + userID
-	removeReq, err := http.NewRequest("DELETE", removeURL, nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error creating request", err.Error())
-		return
-	}
-	setAdminAuthHeaders(r.client, removeReq)
-
-	removeResp, err := httpClient.Do(removeReq)
+	removeResp, err := doRequestWithRetry(ctx, httpClient, r.client, "DELETE", removeURL, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error removing user from project", err.Error())
 		return


### PR DESCRIPTION
## Summary

- Generalises `doWithRetry` to support any HTTP method + body (was GET-only)
- Routes all admin-API calls in `resource_openai_project_group`, `resource_openai_project_user`, and `data_source_openai_group` through the retry helper — previously only the `openai_project_role` data source and the state upgrader had retry
- Adds full jitter to the backoff schedule: actual sleep is uniformly random in `[base/2, base]` instead of fixed `1s, 2s, 4s, 8s, 16s, 30s`. Without jitter, N concurrent requests that all 429 at the same moment retry on the same instants and keep colliding

## Why

Migrating Babbel's OpenAI access from per-user `openai_project_user` to group-based `openai_project_group` creates ~14 attachments per project. Without retry on resource creates, every apply fails with `API error listing project groups: 429`. Plans that read several `data.openai_group` lookups also 429 (no retry there either).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/provider/` passes (existing retry tests updated for jitter range)
- [ ] dev_overrides + manual `terraform plan/apply` against Babbel's users.infrastructure repo to confirm the 14-group convo-pro-ai apply succeeds without 429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced retry behavior for admin API operations: project group/user management and group data source calls now retry on `429` and transient `5xx` errors using full jitter backoff, reducing synchronized retry collisions.
  * Updated documentation to reflect improved retry mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->