### PR TITLE
fix: cache role and group list responses to avoid duplicate admin-API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- The `openai_project_role` data source (singular and plural) and the
+  `openai_group` data source (singular and plural) now share their admin-API
+  list calls across invocations via per-process caches, so a `terraform
+  plan` that declares N role lookups against M projects and K group lookups
+  resolves to M + 1 admin-API list calls instead of N + K. Roles are cached
+  per project ID; groups are cached once for the org. Without this, retry
+  alone (added in v2.2.3) was insufficient — concurrent paginated lookups
+  for the same data still bursted past the admin rate limit and 429'd
+  repeatedly even with jittered backoff.
+
+## [2.2.3]
+
+### Fixed
 - All admin-API HTTP calls in the `openai_project_group` resource (Create/
   Read/Update/Delete), the `openai_project_user` resource (Create/Read/
   Update/Delete), and the `openai_group` data source now retry on `429 Too

--- a/internal/provider/data_source_openai_group.go
+++ b/internal/provider/data_source_openai_group.go
@@ -2,12 +2,8 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -108,73 +104,21 @@ func (d *GroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	apiURL := d.client.OpenAIClient.APIURL
-	var reqURL string
-	if strings.Contains(apiURL, "/v1") {
-		reqURL = strings.TrimSuffix(apiURL, "/v1") + "/v1/organization/groups"
-	} else {
-		reqURL = strings.TrimSuffix(apiURL, "/") + "/v1/organization/groups"
+	groups, err := cachedListAllGroups(ctx, d.client)
+	if err != nil {
+		resp.Diagnostics.AddError("Error listing organization groups", err.Error())
+		return
 	}
 
 	var foundGroup *GroupResponseFramework
-	cursor := ""
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-
-	for foundGroup == nil {
-		parsedURL, err := url.Parse(reqURL)
-		if err != nil {
-			resp.Diagnostics.AddError("Error parsing URL", err.Error())
-			return
-		}
-		q := parsedURL.Query()
-		q.Set("limit", "100")
-		if cursor != "" {
-			q.Set("after", cursor)
-		}
-		parsedURL.RawQuery = q.Encode()
-
-		httpResp, err := doRequestWithRetry(ctx, httpClient, d.client, "GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error executing request", err.Error())
-			return
-		}
-
-		if httpResp.StatusCode != 200 {
-			httpResp.Body.Close()
-			resp.Diagnostics.AddError("API Error", fmt.Sprintf("Status: %s", httpResp.Status))
-			return
-		}
-
-		var listResp GroupListResponse
-		if err := json.NewDecoder(httpResp.Body).Decode(&listResp); err != nil {
-			httpResp.Body.Close()
-			resp.Diagnostics.AddError("Error decoding response", err.Error())
-			return
-		}
-		httpResp.Body.Close()
-
-		for i := range listResp.Data {
-			group := listResp.Data[i]
-			if groupID != "" && group.ID == groupID {
-				foundGroup = &group
-				break
-			}
-			if groupName != "" && strings.EqualFold(group.Name, groupName) {
-				foundGroup = &group
-				break
-			}
-		}
-
-		if foundGroup != nil {
+	for i := range groups {
+		group := groups[i]
+		if groupID != "" && group.ID == groupID {
+			foundGroup = &group
 			break
 		}
-
-		if !listResp.HasMore {
-			break
-		}
-		if len(listResp.Data) > 0 {
-			cursor = listResp.Data[len(listResp.Data)-1].ID
-		} else {
+		if groupName != "" && strings.EqualFold(group.Name, groupName) {
+			foundGroup = &group
 			break
 		}
 	}
@@ -306,71 +250,23 @@ func (d *GroupsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	apiURL := d.client.OpenAIClient.APIURL
-	var reqURL string
-	if strings.Contains(apiURL, "/v1") {
-		reqURL = strings.TrimSuffix(apiURL, "/v1") + "/v1/organization/groups"
-	} else {
-		reqURL = strings.TrimSuffix(apiURL, "/") + "/v1/organization/groups"
+	groups, err := cachedListAllGroups(ctx, d.client)
+	if err != nil {
+		resp.Diagnostics.AddError("Error listing organization groups", err.Error())
+		return
 	}
 
-	allGroups := make([]GroupResultModel, 0)
-	groupIDs := make([]string, 0)
+	allGroups := make([]GroupResultModel, 0, len(groups))
+	groupIDs := make([]string, 0, len(groups))
 
-	cursor := ""
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-	for {
-		parsedURL, err := url.Parse(reqURL)
-		if err != nil {
-			resp.Diagnostics.AddError("Error parsing URL", err.Error())
-			return
-		}
-		q := parsedURL.Query()
-		q.Set("limit", "100")
-		if cursor != "" {
-			q.Set("after", cursor)
-		}
-		parsedURL.RawQuery = q.Encode()
-
-		httpResp, err := doRequestWithRetry(ctx, httpClient, d.client, "GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error executing request", err.Error())
-			return
-		}
-
-		if httpResp.StatusCode != 200 {
-			httpResp.Body.Close()
-			resp.Diagnostics.AddError("API Error", fmt.Sprintf("Status: %s", httpResp.Status))
-			return
-		}
-
-		var listResp GroupListResponse
-		if err := json.NewDecoder(httpResp.Body).Decode(&listResp); err != nil {
-			httpResp.Body.Close()
-			resp.Diagnostics.AddError("Error decoding response", err.Error())
-			return
-		}
-		httpResp.Body.Close()
-
-		for _, g := range listResp.Data {
-			groupModel := GroupResultModel{
-				ID:            types.StringValue(g.ID),
-				Name:          types.StringValue(g.Name),
-				CreatedAt:     types.Int64Value(g.CreatedAt),
-				IsSCIMManaged: types.BoolValue(g.IsSCIMManaged),
-			}
-			allGroups = append(allGroups, groupModel)
-			groupIDs = append(groupIDs, g.ID)
-		}
-
-		if !listResp.HasMore {
-			break
-		}
-		if len(listResp.Data) > 0 {
-			cursor = listResp.Data[len(listResp.Data)-1].ID
-		} else {
-			break
-		}
+	for _, g := range groups {
+		allGroups = append(allGroups, GroupResultModel{
+			ID:            types.StringValue(g.ID),
+			Name:          types.StringValue(g.Name),
+			CreatedAt:     types.Int64Value(g.CreatedAt),
+			IsSCIMManaged: types.BoolValue(g.IsSCIMManaged),
+		})
+		groupIDs = append(groupIDs, g.ID)
 	}
 
 	data.ID = types.StringValue("organization-groups")

--- a/internal/provider/data_source_openai_project_role.go
+++ b/internal/provider/data_source_openai_project_role.go
@@ -2,12 +2,8 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -133,77 +129,37 @@ func (d *ProjectRolesDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	apiURL := d.client.OpenAIClient.APIURL
-	baseURL := strings.TrimSuffix(apiURL, "/v1")
-	baseURL = strings.TrimSuffix(baseURL, "/")
-	reqURL := fmt.Sprintf("%s/v1/projects/%s/roles", baseURL, projectID)
-
 	// Initialize slices to empty to avoid nil (which becomes null in state)
 	allRoles := make([]RoleResultModel, 0)
 	roleIDs := make([]string, 0)
 
-	cursor := ""
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-	for {
-		parsedURL, err := url.Parse(reqURL)
-		if err != nil {
-			resp.Diagnostics.AddError("Error parsing URL", err.Error())
-			return
-		}
-		q := parsedURL.Query()
-		q.Set("limit", "100")
-		if cursor != "" {
-			q.Set("after", cursor)
-		}
-		parsedURL.RawQuery = q.Encode()
+	roles, err := cachedListProjectRolesFull(ctx, d.client, projectID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error listing project roles", err.Error())
+		return
+	}
 
-		httpResp, err := doWithRetry(ctx, httpClient, d.client, parsedURL.String())
-		if err != nil {
-			resp.Diagnostics.AddError("Error executing request", err.Error())
-			return
+	for _, r := range roles {
+		permissions := make([]types.String, len(r.Permissions))
+		for i, p := range r.Permissions {
+			permissions[i] = types.StringValue(p)
 		}
 
-		if httpResp.StatusCode != 200 {
-			httpResp.Body.Close()
-			resp.Diagnostics.AddError("API Error", fmt.Sprintf("Status: %s", httpResp.Status))
-			return
+		description := ""
+		if r.Description != nil {
+			description = *r.Description
 		}
 
-		var listResp RoleListResponse
-		if err := json.NewDecoder(httpResp.Body).Decode(&listResp); err != nil {
-			httpResp.Body.Close()
-			resp.Diagnostics.AddError("Error decoding response", err.Error())
-			return
+		roleModel := RoleResultModel{
+			RoleID:         types.StringValue(r.ID),
+			Name:           types.StringValue(r.Name),
+			Description:    types.StringValue(description),
+			Permissions:    permissions,
+			ResourceType:   types.StringValue(r.ResourceType),
+			PredefinedRole: types.BoolValue(r.PredefinedRole),
 		}
-		httpResp.Body.Close()
-
-		for _, r := range listResp.Data {
-			permissions := make([]types.String, len(r.Permissions))
-			for i, p := range r.Permissions {
-				permissions[i] = types.StringValue(p)
-			}
-
-			description := ""
-			if r.Description != nil {
-				description = *r.Description
-			}
-
-			roleModel := RoleResultModel{
-				RoleID:         types.StringValue(r.ID),
-				Name:           types.StringValue(r.Name),
-				Description:    types.StringValue(description),
-				Permissions:    permissions,
-				ResourceType:   types.StringValue(r.ResourceType),
-				PredefinedRole: types.BoolValue(r.PredefinedRole),
-			}
-			allRoles = append(allRoles, roleModel)
-			roleIDs = append(roleIDs, r.ID)
-		}
-
-		if !listResp.HasMore || listResp.Next == nil {
-			break
-		}
-		cursor = *listResp.Next
+		allRoles = append(allRoles, roleModel)
+		roleIDs = append(roleIDs, r.ID)
 	}
 
 	data.ID = types.StringValue("project-roles-" + projectID)
@@ -325,75 +281,35 @@ func (d *ProjectRoleDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	apiURL := d.client.OpenAIClient.APIURL
-	baseURL := strings.TrimSuffix(apiURL, "/v1")
-	baseURL = strings.TrimSuffix(baseURL, "/")
-	reqURL := fmt.Sprintf("%s/v1/projects/%s/roles", baseURL, projectID)
+	roles, err := cachedListProjectRolesFull(ctx, d.client, projectID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error listing project roles", err.Error())
+		return
+	}
 
-	cursor := ""
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-	for {
-		parsedURL, err := url.Parse(reqURL)
-		if err != nil {
-			resp.Diagnostics.AddError("Error parsing URL", err.Error())
-			return
-		}
-		q := parsedURL.Query()
-		q.Set("limit", "100")
-		if cursor != "" {
-			q.Set("after", cursor)
-		}
-		parsedURL.RawQuery = q.Encode()
-
-		httpResp, err := doWithRetry(ctx, httpClient, d.client, parsedURL.String())
-		if err != nil {
-			resp.Diagnostics.AddError("Error executing request", err.Error())
-			return
-		}
-
-		if httpResp.StatusCode != 200 {
-			httpResp.Body.Close()
-			resp.Diagnostics.AddError("API Error", fmt.Sprintf("Status: %s", httpResp.Status))
-			return
-		}
-
-		var listResp RoleListResponse
-		if err := json.NewDecoder(httpResp.Body).Decode(&listResp); err != nil {
-			httpResp.Body.Close()
-			resp.Diagnostics.AddError("Error decoding response", err.Error())
-			return
-		}
-		httpResp.Body.Close()
-
-		for _, r := range listResp.Data {
-			if strings.EqualFold(r.Name, roleName) {
-				permissions := make([]types.String, len(r.Permissions))
-				for i, p := range r.Permissions {
-					permissions[i] = types.StringValue(p)
-				}
-
-				description := ""
-				if r.Description != nil {
-					description = *r.Description
-				}
-
-				data.RoleID = types.StringValue(r.ID)
-				data.Name = types.StringValue(r.Name)
-				data.Description = types.StringValue(description)
-				data.Permissions = permissions
-				data.ResourceType = types.StringValue(r.ResourceType)
-				data.PredefinedRole = types.BoolValue(r.PredefinedRole)
-				data.ID = types.StringValue(r.ID)
-
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-				return
+	for _, r := range roles {
+		if strings.EqualFold(r.Name, roleName) {
+			permissions := make([]types.String, len(r.Permissions))
+			for i, p := range r.Permissions {
+				permissions[i] = types.StringValue(p)
 			}
-		}
 
-		if !listResp.HasMore || listResp.Next == nil {
-			break
+			description := ""
+			if r.Description != nil {
+				description = *r.Description
+			}
+
+			data.RoleID = types.StringValue(r.ID)
+			data.Name = types.StringValue(r.Name)
+			data.Description = types.StringValue(description)
+			data.Permissions = permissions
+			data.ResourceType = types.StringValue(r.ResourceType)
+			data.PredefinedRole = types.BoolValue(r.PredefinedRole)
+			data.ID = types.StringValue(r.ID)
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			return
 		}
-		cursor = *listResp.Next
 	}
 
 	resp.Diagnostics.AddError(

--- a/internal/provider/helpers_role_lookup.go
+++ b/internal/provider/helpers_role_lookup.go
@@ -26,6 +26,24 @@ var (
 	roleCacheMu sync.Mutex
 	// projectID → lowercased role name → role ID
 	roleCache = map[string]map[string]string{}
+
+	// fullRoleCache stores complete role objects per project. Used by the
+	// `data "openai_project_role"` data source (singular and plural) so that
+	// multiple lookups against the same project — e.g. one for "member" and
+	// one for "owner" — share a single admin-API list call. Without this,
+	// a `terraform plan` declaring N role lookups across M projects fires
+	// N concurrent paginated GETs that burst the admin rate limit even with
+	// retries.
+	fullRoleCacheMu sync.Mutex
+	fullRoleCache   = map[string][]RoleResponseFramework{}
+
+	// groupCache stores all SCIM-managed groups in the org. Used by the
+	// `data "openai_group"` data source (singular and plural). The endpoint
+	// returns the same list regardless of which group name we're filtering
+	// for, so N concurrent group lookups all paginate the same data — cache
+	// once and serve all subsequent lookups from memory.
+	groupCacheMu sync.Mutex
+	groupCache   []GroupResponseFramework
 )
 
 // resetRoleCacheForTest clears the package-level role cache. Used only by tests.
@@ -33,6 +51,14 @@ func resetRoleCacheForTest() {
 	roleCacheMu.Lock()
 	defer roleCacheMu.Unlock()
 	roleCache = map[string]map[string]string{}
+
+	fullRoleCacheMu.Lock()
+	defer fullRoleCacheMu.Unlock()
+	fullRoleCache = map[string][]RoleResponseFramework{}
+
+	groupCacheMu.Lock()
+	defer groupCacheMu.Unlock()
+	groupCache = nil
 }
 
 // projectClientHTTP returns the provider's configured *http.Client when
@@ -85,6 +111,142 @@ func lookupProjectRoleIDByName(ctx context.Context, c *OpenAIClient, projectID, 
 		return id, nil
 	}
 	return "", fmt.Errorf("no role with name %q found in project %s", roleName, projectID)
+}
+
+// cachedListProjectRolesFull returns all roles for the given project, fetching
+// them via the admin API on first call and serving subsequent calls from a
+// per-process cache. The lock is held across the API call so concurrent
+// callers for the same project resolve to a single list-roles request.
+func cachedListProjectRolesFull(ctx context.Context, c *OpenAIClient, projectID string) ([]RoleResponseFramework, error) {
+	if c == nil {
+		return nil, fmt.Errorf("openai client is not configured")
+	}
+	if adminAPIKey(c) == "" {
+		return nil, fmt.Errorf("admin API key is required to list roles for project %s", projectID)
+	}
+
+	fullRoleCacheMu.Lock()
+	defer fullRoleCacheMu.Unlock()
+
+	if cached, ok := fullRoleCache[projectID]; ok {
+		return cached, nil
+	}
+
+	httpClient := projectClientHTTP(c)
+	rolesURL := adminBaseURL(c) + "/v1/projects/" + projectID + "/roles"
+	cursor := ""
+	out := []RoleResponseFramework{}
+
+	for {
+		parsedURL, err := url.Parse(rolesURL)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing roles URL: %w", err)
+		}
+		q := parsedURL.Query()
+		q.Set("limit", "100")
+		if cursor != "" {
+			q.Set("after", cursor)
+		}
+		parsedURL.RawQuery = q.Encode()
+
+		resp, err := doWithRetry(ctx, httpClient, c, parsedURL.String())
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("API error listing project roles for %s: %s", projectID, resp.Status)
+		}
+
+		var listResp RoleListResponse
+		if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("error parsing roles response: %w", err)
+		}
+		resp.Body.Close()
+
+		out = append(out, listResp.Data...)
+
+		if !listResp.HasMore || listResp.Next == nil {
+			break
+		}
+		next := *listResp.Next
+		if next == "" || next == cursor {
+			break
+		}
+		cursor = next
+	}
+
+	fullRoleCache[projectID] = out
+	return out, nil
+}
+
+// cachedListAllGroups returns all SCIM-managed groups in the org, fetching on
+// first call and serving subsequent calls from a per-process cache. The
+// `data "openai_group"` data source filters this list by name client-side; N
+// concurrent group lookups now resolve to a single paginated list call.
+func cachedListAllGroups(ctx context.Context, c *OpenAIClient) ([]GroupResponseFramework, error) {
+	if c == nil {
+		return nil, fmt.Errorf("openai client is not configured")
+	}
+	if adminAPIKey(c) == "" {
+		return nil, fmt.Errorf("admin API key is required to list organization groups")
+	}
+
+	groupCacheMu.Lock()
+	defer groupCacheMu.Unlock()
+
+	if groupCache != nil {
+		return groupCache, nil
+	}
+
+	httpClient := projectClientHTTP(c)
+	groupsURL := adminBaseURL(c) + "/v1/organization/groups"
+	cursor := ""
+	out := []GroupResponseFramework{}
+
+	for {
+		parsedURL, err := url.Parse(groupsURL)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing groups URL: %w", err)
+		}
+		q := parsedURL.Query()
+		q.Set("limit", "100")
+		if cursor != "" {
+			q.Set("after", cursor)
+		}
+		parsedURL.RawQuery = q.Encode()
+
+		resp, err := doWithRetry(ctx, httpClient, c, parsedURL.String())
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("API error listing organization groups: %s", resp.Status)
+		}
+
+		var listResp GroupListResponse
+		if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("error parsing groups response: %w", err)
+		}
+		resp.Body.Close()
+
+		out = append(out, listResp.Data...)
+
+		if !listResp.HasMore || listResp.Next == nil {
+			break
+		}
+		next := *listResp.Next
+		if next == "" || next == cursor {
+			break
+		}
+		cursor = next
+	}
+
+	groupCache = out
+	return out, nil
 }
 
 // listProjectRoles fetches all roles defined in a project and returns them as


### PR DESCRIPTION
## Summary

- `data.openai_project_role` (singular and plural) now share a per-process cache keyed by project ID. N role lookups against M projects → M + 1 admin-API calls instead of N
- `data.openai_group` (singular and plural) cache the org-wide groups list once. K group lookups → 1 admin-API call instead of K

## Why

v2.2.3 added retry to all the right paths but retry alone wasn't enough: concurrent paginated lookups for the same data (e.g. role "member" + role "owner" of the same project) still burst past the admin rate limit (~60 RPM) and 429'd repeatedly.

A Babbel plan with 12 role data sources and 8 group data sources fired ~20 paginated GETs concurrently. Caching collapses this to ~8 calls (one list per unique project + one for groups), well under the limit.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/provider/` passes
- [ ] dev_overrides + manual `terraform plan` against Babbel's users.infrastructure to confirm no 429s