### PR TITLE
fix: skip post-create list when POST returns the created project-group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `openai_project_group` Create no longer issues a paginated list of all
+  groups in the project after a successful POST. The POST response itself
+  is the project-group object, so we parse it directly. The list-and-find
+  fallback now runs only on the idempotent "already exists in project"
+  path. During a parallel apply attaching N groups to one project, this
+  reduces 2N admin-API calls (POST + paginated list per group) to N (POST
+  only), which keeps the admin rate limit from 429'ing the apply mid-flight.
+
+## [2.2.4]
+
+### Fixed
 - The `openai_project_role` data source (singular and plural) and the
   `openai_group` data source (singular and plural) now share their admin-API
   list calls across invocations via per-process caches, so a `terraform

--- a/internal/provider/resource_openai_project_group.go
+++ b/internal/provider/resource_openai_project_group.go
@@ -162,67 +162,73 @@ func (r *ProjectGroupResource) Create(ctx context.Context, req resource.CreateRe
 	defer httpResp.Body.Close()
 
 	respBody, _ := io.ReadAll(httpResp.Body)
-	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusCreated {
-		// If group already exists in project, that's fine — we'll manage roles below
-		if !strings.Contains(string(respBody), "already exists in project") {
-			resp.Diagnostics.AddError("API error adding group to project", fmt.Sprintf("%s - %s", httpResp.Status, string(respBody)))
-			return
-		}
-	}
 
-	// Read group details from the project (works whether we just added or already existed)
+	// Happy path: POST 200/201 returns the created project-group object
+	// directly. Use it without an extra paginated list call (which during
+	// concurrent applies hammers the admin API and 429s).
 	var groupResp ProjectGroupResponseFramework
-	groupsURL := adminBaseURL(r.client) + "/v1/organization/projects/" + projectID + "/groups"
-	cursor := ""
-	for {
-		parsedURL, err := url.Parse(groupsURL)
-		if err != nil {
-			resp.Diagnostics.AddError("Error parsing URL", err.Error())
+	switch {
+	case httpResp.StatusCode == http.StatusOK || httpResp.StatusCode == http.StatusCreated:
+		if err := json.Unmarshal(respBody, &groupResp); err != nil || groupResp.GroupID == "" {
+			resp.Diagnostics.AddError("Error parsing add-group response", fmt.Sprintf("%s - %s", err, string(respBody)))
 			return
 		}
-		q := parsedURL.Query()
-		q.Set("limit", "100")
-		if cursor != "" {
-			q.Set("after", cursor)
-		}
-		parsedURL.RawQuery = q.Encode()
+	case strings.Contains(string(respBody), "already exists in project"):
+		// Idempotent path: group was already attached. List-and-find to
+		// recover the existing object.
+		groupsURL := adminBaseURL(r.client) + "/v1/organization/projects/" + projectID + "/groups"
+		cursor := ""
+		for {
+			parsedURL, perr := url.Parse(groupsURL)
+			if perr != nil {
+				resp.Diagnostics.AddError("Error parsing URL", perr.Error())
+				return
+			}
+			q := parsedURL.Query()
+			q.Set("limit", "100")
+			if cursor != "" {
+				q.Set("after", cursor)
+			}
+			parsedURL.RawQuery = q.Encode()
 
-		listResp, err := doRequestWithRetry(ctx, httpClient, r.client, "GET", parsedURL.String(), nil)
-		if err != nil {
-			resp.Diagnostics.AddError("Error listing project groups", err.Error())
-			return
-		}
-
-		if listResp.StatusCode != http.StatusOK {
+			listResp, lerr := doRequestWithRetry(ctx, httpClient, r.client, "GET", parsedURL.String(), nil)
+			if lerr != nil {
+				resp.Diagnostics.AddError("Error listing project groups", lerr.Error())
+				return
+			}
+			if listResp.StatusCode != http.StatusOK {
+				listResp.Body.Close()
+				resp.Diagnostics.AddError("API error listing project groups", fmt.Sprintf("API returned: %s", listResp.Status))
+				return
+			}
+			var listData ProjectGroupListResponse
+			if derr := json.NewDecoder(listResp.Body).Decode(&listData); derr != nil {
+				listResp.Body.Close()
+				resp.Diagnostics.AddError("Error parsing response", derr.Error())
+				return
+			}
 			listResp.Body.Close()
-			resp.Diagnostics.AddError("API error listing project groups", fmt.Sprintf("API returned: %s", listResp.Status))
-			return
-		}
 
-		var listData ProjectGroupListResponse
-		if err := json.NewDecoder(listResp.Body).Decode(&listData); err != nil {
-			listResp.Body.Close()
-			resp.Diagnostics.AddError("Error parsing response", err.Error())
-			return
-		}
-		listResp.Body.Close()
-
-		found := false
-		for i := range listData.Data {
-			if listData.Data[i].GroupID == groupID {
-				groupResp = listData.Data[i]
-				found = true
+			found := false
+			for i := range listData.Data {
+				if listData.Data[i].GroupID == groupID {
+					groupResp = listData.Data[i]
+					found = true
+					break
+				}
+			}
+			if found {
 				break
 			}
+			if !listData.HasMore || listData.Next == nil {
+				resp.Diagnostics.AddError("Group not found", fmt.Sprintf("Group %s not found in project %s after adding", groupID, projectID))
+				return
+			}
+			cursor = *listData.Next
 		}
-		if found {
-			break
-		}
-		if !listData.HasMore || listData.Next == nil {
-			resp.Diagnostics.AddError("Group not found", fmt.Sprintf("Group %s not found in project %s after adding", groupID, projectID))
-			return
-		}
-		cursor = *listData.Next
+	default:
+		resp.Diagnostics.AddError("API error adding group to project", fmt.Sprintf("%s - %s", httpResp.Status, string(respBody)))
+		return
 	}
 
 	// Step 2: Assign additional roles (first one was set via membership endpoint)


### PR DESCRIPTION
## Summary

POST /v1/organization/projects/{id}/groups returns the created project-group object on success. Use it directly instead of issuing a paginated list-and-find afterwards. The list path now runs only on the idempotent 'already exists in project' branch.

## Why

During a parallel apply attaching N groups to one project, the previous flow did 2N admin-API calls (POST + paginated GET per group). With OpenAI's ~60 RPM limit, N=14 still triggered 429 mid-apply even with the v2.2.3 retry helper. Skipping the list cuts traffic in half on the happy path.

## Test plan

- [x] go build, go test
- [ ] manual apply against Babbel users.infrastructure to confirm no 429s on convo-pro-ai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Project group creation now performs fewer API calls by directly processing responses instead of listing all groups. This prevents rate limit errors when attaching multiple groups in parallel, improving reliability during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->