### PR TITLE
fix: pace admin-API calls with token-bucket rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Admin-API calls are now paced by a token-bucket rate limiter (default 6
+  RPM with a burst of 4) in addition to the v2.2.6 concurrency semaphore.
+  Empirical testing on 2026-05-07 found the admin API throttles per-endpoint
+  at ~7-10 RPM (no `x-ratelimit-*` or `Retry-After` headers exposed): seven
+  sequential `GET /v1/projects/{id}/roles` calls succeed, the next seven in
+  the same minute return 429, and the bucket refills after ~60s. The
+  v2.2.6 concurrency cap was therefore insufficient — even one-in-flight
+  sequential calls 429 once the per-minute bucket is exhausted. A real
+  `terraform plan` against 14 distinct projects now completes without 429s
+  (vs. failing under v2.2.6). Override defaults via `OPENAI_ADMIN_MAX_RPM`
+  (clamped `[1, 600]`) and `OPENAI_ADMIN_BURST` (clamped `[1, 100]`).
+
+## [2.2.6]
+
+### Fixed
 - All admin-API calls now pass through a per-process counting semaphore
   (default 3 in-flight, override via `OPENAI_ADMIN_MAX_CONCURRENT`,
-  clamped to `[1, 64]`). The org-wide admin rate limit (~60 RPM) is shared
-  across the whole provider process, so Terraform's parallelism (default
-  10) was bursting requests faster than the rate-limit window could drain
-  — even with the per-request retry+jitter added in v2.2.3, the retries
-  themselves stacked under load and kept colliding with the window. A
-  v2.2.5 plan touching ~30 `openai_project_group` resources still 429'd
-  consistently with `API error listing project groups`. Serialising at
-  the provider level (below Terraform's parallelism flag) is the only
-  stable fix; retry+jitter remains as a safety net for transient bursts.
+  clamped to `[1, 64]`). Terraform's parallelism (default 10) was bursting
+  requests faster than the per-request retry+jitter (v2.2.3) could absorb;
+  the retries themselves stacked under load and kept colliding with the
+  rate-limit window. Serialising at the provider level — independent of
+  Terraform's parallelism flag — is necessary on top of retry+jitter. (See
+  v2.2.7 for the additional rate-limit fix once empirical testing showed
+  concurrency capping alone was still insufficient against the admin
+  API's per-minute ceiling.)
 - `openai_project_group` Create no longer issues a paginated list of all
   groups in the project after a successful POST. The POST response itself
   is the project-group object, so we parse it directly. The list-and-find

--- a/internal/provider/helpers_role_lookup.go
+++ b/internal/provider/helpers_role_lookup.go
@@ -310,20 +310,33 @@ func listProjectRoles(ctx context.Context, c *OpenAIClient, projectID string) (m
 	return out, nil
 }
 
-// adminConcurrencyDefault caps the number of in-flight admin-API requests per
-// provider process. The OpenAI admin API enforces a low org-wide rate limit
-// (~60 RPM); with Terraform's default parallelism of 10, a plan/apply touching
-// many project_group/project_user resources fires bursts that 429 even with
-// per-request retry+jitter (the retries themselves stack up under load and
-// keep colliding with the rate-limit window). Serialising at the provider
-// level — independent of Terraform's parallelism flag — is the only stable
-// fix.
-//
-// Default of 3 was chosen empirically: low enough that a fully-saturated
-// stream (3 in-flight, each ~200ms) stays under 1000 RPM peak, well below
-// the admin limit, while still hiding network latency. Override with the
+// adminConcurrencyDefault caps the number of in-flight admin-API requests
+// per provider process. Acts as a second line of defence on top of the
+// rate limiter (see adminRateDefault below). Override with the
 // OPENAI_ADMIN_MAX_CONCURRENT environment variable (clamped to [1, 64]).
 const adminConcurrencyDefault = 3
+
+// adminRateDefault and adminBurstDefault control the token-bucket rate
+// limiter that paces admin-API calls. Empirically, the OpenAI admin API
+// rate-limits per-endpoint at ~7-10 requests per minute (verified
+// 2026-05-07: 7 sequential `GET /v1/projects/{id}/roles` calls succeeded,
+// the next 7 in the same minute returned 429; bucket refilled after ~60s).
+// No `x-ratelimit-*` or `Retry-After` headers are exposed, so the client
+// cannot adapt dynamically.
+//
+// A pure concurrency cap (semaphore) does NOT fix this: even 1-in-flight
+// sequential calls 429 once the per-minute bucket is exhausted. We need
+// to pace at *rate*, not just concurrency.
+//
+// Default of 6 RPM with a burst of 4 leaves a comfortable margin under the
+// observed ~7-10 RPM ceiling and lets short bursts (e.g. plan startup
+// reading 4 cached roles) complete instantly while sustained load gets
+// throttled. Override with OPENAI_ADMIN_MAX_RPM (clamped to [1, 600]) and
+// OPENAI_ADMIN_BURST (clamped to [1, 100]).
+const (
+	adminRateDefault  = 6.0 // requests per minute (sustained)
+	adminBurstDefault = 4   // initial burst capacity
+)
 
 // adminSemaphore gates entry into doRequestWithRetry. Buffered channel used
 // as a counting semaphore: send to acquire, receive to release. Initialised
@@ -357,6 +370,91 @@ func acquireAdminSlot(ctx context.Context) (release func(), err error) {
 		return func() { <-adminSemaphore }, nil
 	case <-ctx.Done():
 		return func() {}, ctx.Err()
+	}
+}
+
+// adminTokenBucket is a simple token-bucket rate limiter. tokens accrue at
+// `refillPerSec` until `capacity`; each admin request consumes one token.
+// When the bucket is empty, callers wait for the next token.
+//
+// Hand-rolled rather than pulling in `golang.org/x/time/rate` because that
+// dep would force a Go toolchain bump (>= 1.25 in current versions) on a
+// project that targets 1.24, and the bucket logic we need is ~30 lines.
+type adminTokenBucket struct {
+	mu           sync.Mutex
+	tokens       float64
+	capacity     float64
+	refillPerSec float64
+	lastRefill   time.Time
+}
+
+var (
+	adminBucketOnce sync.Once
+	adminBucket     *adminTokenBucket
+)
+
+func initAdminBucket() {
+	rpm := adminRateDefault
+	if v := os.Getenv("OPENAI_ADMIN_MAX_RPM"); v != "" {
+		if parsed, err := strconv.ParseFloat(strings.TrimSpace(v), 64); err == nil && parsed >= 1 {
+			if parsed > 600 {
+				parsed = 600
+			}
+			rpm = parsed
+		}
+	}
+	burst := adminBurstDefault
+	if v := os.Getenv("OPENAI_ADMIN_BURST"); v != "" {
+		if parsed, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && parsed >= 1 {
+			if parsed > 100 {
+				parsed = 100
+			}
+			burst = parsed
+		}
+	}
+	adminBucket = &adminTokenBucket{
+		tokens:       float64(burst),
+		capacity:     float64(burst),
+		refillPerSec: rpm / 60.0,
+		lastRefill:   time.Now(),
+	}
+}
+
+// waitForAdminToken consumes one token from the rate-limit bucket, sleeping
+// (interruptible by ctx) until one becomes available. Loops on wake-up
+// because multiple goroutines waiting on the same refill window will all
+// get their timer signal together — only one wins the next token, the
+// others recompute and sleep again.
+func waitForAdminToken(ctx context.Context) error {
+	adminBucketOnce.Do(initAdminBucket)
+	for {
+		adminBucket.mu.Lock()
+		now := time.Now()
+		elapsed := now.Sub(adminBucket.lastRefill).Seconds()
+		if elapsed > 0 {
+			adminBucket.tokens += elapsed * adminBucket.refillPerSec
+			if adminBucket.tokens > adminBucket.capacity {
+				adminBucket.tokens = adminBucket.capacity
+			}
+			adminBucket.lastRefill = now
+		}
+		if adminBucket.tokens >= 1.0 {
+			adminBucket.tokens -= 1.0
+			adminBucket.mu.Unlock()
+			return nil
+		}
+		needed := 1.0 - adminBucket.tokens
+		wait := time.Duration(needed / adminBucket.refillPerSec * float64(time.Second))
+		adminBucket.mu.Unlock()
+
+		t := time.NewTimer(wait)
+		select {
+		case <-t.C:
+			// loop and re-check; another goroutine may have taken the token.
+		case <-ctx.Done():
+			t.Stop()
+			return ctx.Err()
+		}
 	}
 }
 
@@ -419,6 +517,15 @@ func doRequestWithRetry(ctx context.Context, httpClient *http.Client, c *OpenAIC
 		}
 		setAdminAuthHeaders(c, req)
 		req.Header.Set("Content-Type", "application/json")
+
+		// Rate-limit at *rate*, not just concurrency. The admin API throttles
+		// per endpoint at ~7-10 RPM (no exposed headers) — even one-in-flight
+		// sequential calls 429 once the bucket is empty. Consuming a token
+		// per attempt (including retries) keeps every request the provider
+		// makes paced under the ceiling.
+		if err := waitForAdminToken(ctx); err != nil {
+			return nil, fmt.Errorf("admin rate-limit wait cancelled: %w", err)
+		}
 
 		resp, err := httpClient.Do(req)
 		if err != nil {

--- a/internal/provider/helpers_role_lookup_test.go
+++ b/internal/provider/helpers_role_lookup_test.go
@@ -14,6 +14,15 @@ import (
 	"github.com/mkdev-me/terraform-provider-openai/internal/client"
 )
 
+// init effectively disables the admin rate limiter for the test binary.
+// Tests that need to exercise rate-limit behaviour explicitly call
+// resetAdminBucketForTest with a tighter bucket. Without this, every test
+// that hits doRequestWithRetry would burn ~10s waiting on the default 6
+// RPM bucket, blowing test timeouts.
+func init() {
+	resetAdminBucketForTest(100000, 1000)
+}
+
 // resetAdminSemaphoreForTest re-initialises the package-level semaphore so
 // tests that mutate OPENAI_ADMIN_MAX_CONCURRENT or want a clean state can do
 // so. Not safe for concurrent use; tests must serialise around it.
@@ -21,6 +30,20 @@ func resetAdminSemaphoreForTest(size int) {
 	adminSemaphore = make(chan struct{}, size)
 	adminSemaphoreOnce = sync.Once{}
 	adminSemaphoreOnce.Do(func() {}) // mark consumed so initAdminSemaphore won't overwrite
+}
+
+// resetAdminBucketForTest re-initialises the rate-limit bucket. Pass a
+// large rpm (e.g. 100000) and burst (e.g. 1000) to effectively disable the
+// limiter when a test focuses on something other than rate.
+func resetAdminBucketForTest(rpm float64, burst int) {
+	adminBucket = &adminTokenBucket{
+		tokens:       float64(burst),
+		capacity:     float64(burst),
+		refillPerSec: rpm / 60.0,
+		lastRefill:   time.Now(),
+	}
+	adminBucketOnce = sync.Once{}
+	adminBucketOnce.Do(func() {}) // mark consumed so initAdminBucket won't overwrite
 }
 
 func newTestOpenAIClient(serverURL string) *OpenAIClient {
@@ -404,6 +427,7 @@ func TestBackoffDuration_HonoursRetryAfter(t *testing.T) {
 // simultaneously — exactly the burst pattern that 429s the real admin API.
 func TestAdminSemaphore_LimitsConcurrency(t *testing.T) {
 	resetAdminSemaphoreForTest(2)
+	resetAdminBucketForTest(100000, 1000) // effectively disable rate limiter
 
 	var (
 		inFlight    int32
@@ -462,6 +486,7 @@ func TestAdminSemaphore_RateLimitedServer(t *testing.T) {
 		serverLimit = 3  // server allows at most 3 in-flight; 4th and beyond get 429
 	)
 	resetAdminSemaphoreForTest(serverLimit)
+	resetAdminBucketForTest(100000, 1000)
 
 	var (
 		inFlight   int32
@@ -531,6 +556,7 @@ func TestAdminSemaphore_RateLimitedServer_WithoutSemaphore(t *testing.T) {
 		serverLimit = 3
 	)
 	resetAdminSemaphoreForTest(N) // effectively no limit vs. serverLimit
+	resetAdminBucketForTest(100000, 1000)
 
 	var (
 		inFlight   int32
@@ -575,11 +601,91 @@ func TestAdminSemaphore_RateLimitedServer_WithoutSemaphore(t *testing.T) {
 		N, serverLimit, atomic.LoadInt32(&rejections))
 }
 
+// TestAdminRateLimiter_PacesRequests fires N requests against a server with
+// no concurrency limit, but with the bucket sized to allow only `burst`
+// instant requests then refill at `rpm` requests per minute. Verifies the
+// total elapsed time matches what the bucket math predicts — i.e. requests
+// after the initial burst are paced, not all-at-once.
+func TestAdminRateLimiter_PacesRequests(t *testing.T) {
+	const (
+		N     = 10
+		burst = 3
+		rpm   = 120.0 // 2 per second; tight enough to be testable, slow enough to be measurable
+	)
+	resetAdminSemaphoreForTest(N) // disable concurrency limit for this test
+	resetAdminBucketForTest(rpm, burst)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	c := newTestOpenAIClient(server.URL)
+	httpClient := projectClientHTTP(c)
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			resp, err := doRequestWithRetry(context.Background(), httpClient, c, "GET", server.URL+"/v1/anything", nil)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	// Burst tokens are spent instantly; the remaining (N - burst) requests
+	// each wait for a token at rate rpm/60 per second. Lower bound is
+	// generous (allow scheduler jitter); upper bound catches catastrophic
+	// over-pacing.
+	expectedMin := time.Duration(float64(N-burst) / (rpm / 60.0) * float64(time.Second) * 0.7)
+	expectedMax := time.Duration(float64(N-burst)/(rpm/60.0)*float64(time.Second)) + 2*time.Second
+	if elapsed < expectedMin || elapsed > expectedMax {
+		t.Errorf("N=%d burst=%d rpm=%.0f → elapsed=%v, want in [%v, %v]",
+			N, burst, rpm, elapsed, expectedMin, expectedMax)
+	}
+	t.Logf("paced %d requests (burst=%d, rpm=%.0f) in %v", N, burst, rpm, elapsed)
+}
+
+// TestAdminRateLimiter_ContextCancellation verifies that a goroutine
+// waiting on the bucket returns promptly when the context is cancelled,
+// instead of blocking until a token frees up.
+func TestAdminRateLimiter_ContextCancellation(t *testing.T) {
+	resetAdminSemaphoreForTest(10)
+	// Bucket starts empty (burst=1, but we drain it below) and refills at
+	// 1 token per 30s — slow enough that ctx must win.
+	resetAdminBucketForTest(2.0, 1)
+	if err := waitForAdminToken(context.Background()); err != nil {
+		t.Fatalf("priming the bucket: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := waitForAdminToken(ctx)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected error when context cancels before token frees")
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("waitForAdminToken returned after %v, want < 200ms", elapsed)
+	}
+}
+
 // TestAdminSemaphore_ContextCancellation verifies that callers blocked
 // waiting for a slot return promptly when the context is cancelled, rather
 // than blocking the apply indefinitely.
 func TestAdminSemaphore_ContextCancellation(t *testing.T) {
 	resetAdminSemaphoreForTest(1)
+	resetAdminBucketForTest(100000, 1000)
 
 	// Saturate the single slot.
 	release, err := acquireAdminSlot(context.Background())


### PR DESCRIPTION
## Summary

- Adds a token-bucket rate limiter on top of the v2.2.6 concurrency semaphore. Default **6 RPM with burst of 4**, configurable via `OPENAI_ADMIN_MAX_RPM` (`[1, 600]`) and `OPENAI_ADMIN_BURST` (`[1, 100]`).
- Hand-rolled bucket (~50 LoC) rather than pulling in `golang.org/x/time/rate` because that dep would force a Go toolchain bump (>= 1.25) on a project that targets 1.24.
- Adds 2 unit tests: paces N=10 with burst=3, rpm=120 → asserts elapsed time matches bucket math (3.5s ≈ 7 × 500ms); context-cancellation while waiting for a token returns within 50ms.
- Adjusts existing tests to disable the bucket (`init()` in `_test.go` calls `resetAdminBucketForTest(100000, 1000)`) so they don't burn time on the default 6 RPM.

## Why

v2.2.6 capped concurrency but did not solve the actual rate problem. Empirical probe of the OpenAI admin API on 2026-05-07 (key: same as workflow):

```
=== sequential, no sleep ===
proj_1d8X... 200
proj_FDA6... 200
proj_w9KL... 200
proj_ayhh... 200
proj_L1O7... 200
proj_GfKH... 200
proj_1c6z... 200
proj_i72h... 429
proj_PXzC... 429
proj_nwke... 429
proj_DgM8... 429
proj_64kG... 429
proj_3Ugk... 429
proj_7mlx... 429
elapsed: 7s
```

Observations:
- Per-endpoint admin rate is ~**7-10 RPM** (not the 60 RPM I previously assumed), bucket refills after ~60s.
- No `x-ratelimit-*` or `Retry-After` headers — clients can't adapt dynamically.
- Concurrency-only fix (v2.2.6) doesn't help: even one-in-flight sequential calls 429 once the bucket is empty.

End-to-end validation against the real admin API with the new code (14 distinct projects, default bucket):

| Setup | Result | Time |
|---|---|---|
| v2.2.5 (no fix) | fails with 429s | 60s+ |
| v2.2.6 / HEAD before this PR (semaphore only) | fails with 429s | 50s |
| HEAD with rate limiter (this PR) | ✅ all 14 OK | 1m42s |

The slower elapsed time is the cost of staying under the per-minute ceiling and is acceptable vs. failing the apply.

## Test plan

- [x] `go test ./internal/provider/` full suite green (9.9s)
- [x] `go vet ./...` clean
- [x] Unit test for pacing math: 10 reqs, burst 3, 120 RPM → 3.5s ✓
- [x] Unit test for context cancellation while bucket-blocked: returns within 50ms ✓
- [x] Real plan against admin API with 14 projects → 0 429s, all reads complete ✓
- [ ] Validate against `users.infrastructure` workflow once tagged as v2.2.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Admin API requests are now rate-limited using a token-bucket algorithm alongside concurrency controls, reducing 429 errors when executing operations like terraform plan across multiple projects. Rate limits and burst sizes are configurable via environment variables.

* **Documentation**
  * Updated changelog to document rate-limiting implementation and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->