### PR TITLE
fix: make GHA workflows work for PRs from forks (Release Drafter via pull_request_target, least-privilege CI token)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - main
 
+# CI builds and runs code from the PR, so it must stay on the pull_request
+# trigger (untrusted forks only get a read-only token there) and never needs
+# more than read access itself.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  # pull_request_target (not pull_request) is required for the autolabeler to
+  # work on PRs from forks: the workflow and release-drafter config are read
+  # from the trusted base branch, no PR code is checked out or executed, and
+  # the token keeps the write permissions the autolabeler needs.
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
# Description

Fork PRs (e.g. #78, #66) appear to never trigger our GHA workflows. Investigation showed the workflow **triggers were already correct** — a bare `pull_request:` does fire for forks. Two separate things were going on:

1. **CI is held by GitHub's fork-PR approval gate.** This repo uses GitHub's default policy *"Require approval for first-time contributors"*. Both fork PRs ever opened (#78, #66) are from `FIRST_TIME_CONTRIBUTOR`s, so their workflow runs sit invisibly awaiting maintainer approval — no runs or check suites appear in the API/Actions tab until someone clicks **"Approve workflows to run"** in the PR's merge box. #66 shows exactly this: its CI only ran 16 days after the push, when a maintainer manually approved it (`triggering_actor: Fodoj`, `run_attempt: 2`). This is by design and **cannot** (and should not) be bypassed in workflow YAML: CI executes untrusted fork code, and moving it to `pull_request_target` would expose a write token and the base-branch Actions cache (setup-go cache poisoning) to that code — the classic [pwn request](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).

2. **Release Drafter could never work on fork PRs even after approval.** On `pull_request` events from forks the `GITHUB_TOKEN` is read-only, so the autolabeler can't add labels. The [release-drafter README](https://github.com/release-drafter/release-drafter#usage) documents the fix: *"pull_request_target event is required for autolabeler to support PRs from forks"*. This is safe for this specific workflow: it never checks out or executes PR code (the job's only step is the `release-drafter@v6` action), and both the workflow definition and `.github/release-drafter.yml` config are read from the trusted base branch. As a bonus, `pull_request_target` runs are exempt from the approval gate, so fork PRs get labeled immediately.

This PR therefore:
- switches `release-drafter.yml`'s PR trigger from `pull_request` to `pull_request_target` (same event types);
- adds an explicit `permissions: contents: read` to `ci.yml` (the repo's default workflow token permission is `write`; CI never needs it — least-privilege hardening that matters now that we expect fork traffic).

**What this PR intentionally does NOT do:** make CI run automatically for first-time fork contributors. That needs one of:
- a one-time click of **"Approve workflows to run"** on the PR (note: runs awaiting approval are auto-deleted after 30 days — if the button is gone on #78, close/reopen the PR to regenerate the event, then approve); or
- relaxing the repo setting to *"Require approval for first-time contributors who are new to GitHub"*:
  `gh api -X PUT repos/mkdev-me/terraform-provider-openai/actions/permissions/fork-pr-contributor-approval -f approval_policy=first_time_contributors_new_to_github`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

YAML validated locally; the `pull_request_target` block mirrors the release-drafter README example verbatim (incl. event types). Behavior verified against GitHub docs ([approval gate](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/approve-runs-from-forks), [pull_request_target exemption](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)) and against this repo's own history (fork PR #66 ran only after manual approval; same-repo PR #76 ran instantly).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to enhance security and reliability of automated build and pull request processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->